### PR TITLE
Made Python decorated worker docs clearer

### DIFF
--- a/docs/getting-started/adding-custom-code-worker.md
+++ b/docs/getting-started/adding-custom-code-worker.md
@@ -91,9 +91,14 @@ def execute(task: Task) -> TaskResult:
     return task_result
 
 # Create worker using a WorkerTask decorator
-@WorkerTask(task_definition_name='python_annotated_task', domain='cool', worker_id='decorated', poll_interval_seconds=1.0)
+@WorkerTask(task_definition_name='python_annotated_task', worker_id='decorated')
 def python_annotated_task(input) -> object:
-    return {'message': 'python is so cool :)'}
+    return {'message': 'python is so great :)'}
+
+# Create worker with domain using a WorkerTask decorator 
+@WorkerTask(task_definition_name='python_annotated_task', worker_id='decorated_domain', domain='cool')
+def python_annotated_task_with_domain(input) -> object:
+    return {'message': 'python is so great and cool :)'}
 
 configuration = Configuration(
     server_api_url=SERVER_API_URL,


### PR DESCRIPTION
Added a Python decorated worker snippet example for domain separate from a general worker.

Before the change:
![Screenshot 2023-11-03 at 4 13 15 PM](https://github.com/orkes-io/docs/assets/127052609/d0a3681c-891a-4045-992f-9e3da653d7be)

After the change:
![Screenshot 2023-11-03 at 4 12 45 PM](https://github.com/orkes-io/docs/assets/127052609/7ad03b65-ece5-4e15-b6cf-ddfa0503aaac)
