### PR TITLE
Changes to C# code example

### DIFF
--- a/docs/developer-guides/using-workers.md
+++ b/docs/developer-guides/using-workers.md
@@ -339,15 +339,15 @@ orkesConductorClient({
 <TabItem value="csharp" label="C#">
 
  ``` csharp
-ApiExtensions.Configuration = new Configuration
+var conf = new Configuration
 {
     BasePath = "https://developer.orkescloud.com/api",
     AuthenticationSettings = new OrkesAuthenticationSettings("_CHANGE_ME_", "_CHANGE_ME_")
 };
 
 var host = WorkflowTaskHost.CreateWorkerHost(
-    ApiExtensions.Configuration,
-    LogLevel.Information
+    conf,
+    LogLevel.Debug
 );
 host.Start();
  ```


### PR DESCRIPTION
NIT: In `1.1.0` we no longer need to initialize `ApiExtensions.Configuration = new Configuration` to run workers.