### PR TITLE
Add Changelog links, asset, and resource entry

### DIFF
--- a/docs/what-is-orkes-conductor.mdx
+++ b/docs/what-is-orkes-conductor.mdx
@@ -21,7 +21,7 @@ import {
 
 <main className={`mainContainer container`}>
 <NewToConductorSection
-  title="Build AI Agents and Workflows: Scale With Confidence."
+  title="Build AI Agents and Workflows: Scale With Confidence"
   description={
     <div>
       Orkes Conductor is the battle-tested orchestration platform rooted in open source; with built-in reliability, observability, and control.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -170,14 +170,8 @@ const config = {
             label: "API Reference",
           },
           {
-            href: "https://orkes.io/academy/",
-            label: "Academy",
-            position: "right",
-          },
-          {
-            href: "https://github.com/conductor-oss/conductor",
-            label: "GitHub",
-            target: "_orkes_io",
+            href: "https://www.orkes.io/changelog",
+            label: "Changelog",
             position: "right",
           },
           {
@@ -252,6 +246,10 @@ const config = {
               {
                 label: "Academy",
                 href: "https://orkes.io/academy/",
+              },
+              {
+                label: "Changelog",
+                href: "https://www.orkes.io/changelog",
               },
               {
                 label: "Video Guides",

--- a/src/components/_Sections.js
+++ b/src/components/_Sections.js
@@ -161,6 +161,14 @@ const accordionData = [
 
 const moreResoucesData = [
   {
+    title: "Changelog",
+    description:
+      "See what's new in Orkes Conductor: features, enhancements, and product updates.",
+    logo: "/content/img/svg/more-resources/changelog.svg",
+    url: "https://www.orkes.io/changelog",
+    ctaLabel: "View changelog",
+  },
+  {
     title: "Academy",
     description:
       "Learn workflow orchestration with hands-on labs, structured paths, and certification from Orkes.",
@@ -175,14 +183,6 @@ const moreResoucesData = [
     logo: "/content/img/svg/more-resources/blogs.svg",
     url: "https://orkes.io/blog/",
     ctaLabel: "Read blogs",
-  },
-  {
-    title: "Developer Events",
-    description:
-      "Upcoming webinars, workshops, and developer events from Orkes.",
-    logo: "/content/img/svg/more-resources/dev-events.svg",
-    url: "https://orkes.io/events/",
-    ctaLabel: "Check upcoming events",
   },
 ];
 export const StepBoxesSection = ({ steps = [] }) => (

--- a/static/img/svg/more-resources/changelog.svg
+++ b/static/img/svg/more-resources/changelog.svg
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="Layer_1" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 100 100">
+  <defs>
+    <style>
+      .st0 { fill: #333; }
+      .st1 { fill: #fff; }
+    </style>
+  </defs>
+
+  <!-- Main wide browser/window frame, like blogs.svg -->
+  <path class="st0" d="M86.5,14.5H13.5c-3.311,0-6,2.689-6,6v49c0,3.311,2.689,6,6,6h73c3.311,0,6-2.689,6-6v-49c0-3.311-2.689-6-6-6ZM90.5,69.5c0,2.206-1.794,4-4,4H13.5c-2.206,0-4-1.794-4-4v-39h81v39ZM90.5,28.5H9.5v-8c0-2.206,1.794-4,4-4h73c2.206,0,4,1.794,4,4v8Z"/>
+
+  <!-- Window dots -->
+  <circle class="st0" cx="16" cy="21.5" r="2"/>
+  <circle class="st0" cx="23" cy="21.5" r="2"/>
+  <circle class="st0" cx="30" cy="21.5" r="2"/>
+
+  <!-- Bullet list lines in main area -->
+  <circle class="st0" cx="19" cy="42" r="2.2"/>
+  <rect class="st0" x="25" y="40.1" width="30" height="3.8" rx="1.9"/>
+
+  <circle class="st0" cx="19" cy="52" r="2.2"/>
+  <rect class="st0" x="25" y="50.1" width="30" height="3.8" rx="1.9"/>
+
+  <circle class="st0" cx="19" cy="62" r="2.2"/>
+  <rect class="st0" x="25" y="60.1" width="22" height="3.8" rx="1.9"/>
+
+  <!-- Version tag badge (overlapping right side) -->
+  <circle class="st0" cx="74" cy="58" r="18"/>
+  <!-- Tag pentagon in white -->
+  <polygon class="st1" points="63,49 78,49 85,58 78,67 63,67"/>
+  <!-- Tag hole -->
+  <circle class="st0" cx="66.5" cy="58" r="2.5"/>
+
+</svg>


### PR DESCRIPTION
Expose the Changelog across the site: add a Changelog nav/footer link (docusaurus.config.js), add a Changelog entry to the More Resources data (src/components/_Sections.js), and include the changelog SVG asset (static/img/svg/more-resources/changelog.svg). Also remove the Developer Events resource and replace the previous GitHub/nav entry. Minor copy edit: remove trailing period from the Conductor landing title (docs/what-is-orkes-conductor.mdx).