### PR TITLE
doc updates

### DIFF
--- a/docs/conceptual-guides/architecture.mdx
+++ b/docs/conceptual-guides/architecture.mdx
@@ -15,7 +15,7 @@ Before you read this article, you should understand:
 
 <p align="center"><img src="/content/img/conductor-architecture.jpg" alt="Conductor architecture" width="90%" height="auto" style={{paddingBottom: 10, paddingTop: 10}} /></p>
 
-In Conductor, a workflow contains tasks in a defined order. You can trigger workflows by code, an API call, a cron schedule, webhooks, or external eventing systems such as AWS SQS and Kafka.
+In Conductor, a workflow contains tasks in a defined order. You can trigger workflows by code, an API call, a cron schedule, webhooks, or external eventing systems such as AWS SQS and Kafka. The FIFO guarantee applies to task execution within a running workflow. When workflows are triggered by external event systems like Kafka or SQS, ordering depends on how those systems deliver messages and is not covered by Conductor's internal task queue ordering.
 
 In Conductor, workflows are executed on a worker-task queue architecture, where each task type (HTTP, Event, Wait, and so on) has its own dedicated task queue. The key components of Conductor’s core orchestration engine include:
 

--- a/docs/developer-guides/event-handler.mdx
+++ b/docs/developer-guides/event-handler.mdx
@@ -352,3 +352,13 @@ Starts a new workflow instance.
 | actions. start_workflow. **idempotencyStrategy** | The idempotency strategy for handling duplicate requests. Supported values:<ul><li>`RETURN_EXISTING`: Return the `workflowId` of the workflow instance with the same idempotency key.</li> <li>`FAIL`: Start a new workflow instance only if there are no workflow executions with the same idempotency key.</li> <li>`FAIL_ON_RUNNING`: Start a new workflow instance only if there are no RUNNING or PAUSED workflows with the same idempotency key. Completed workflows can run again.</li></ul> | Required if `idempotencyKey` is used. | 
 | actions. start_workflow. **input** | The input data to be passed to the new workflow. Can be string, number, boolean, null, or object/array. | Optional. | 
 | actions. start_workflow. **taskToDomain** | A mapping of task reference names to domain-specific values to [route the task to defined workers](https://orkes.io/content/developer-guides/task-to-domain). | Optional. | 
+
+**Ordering behavior with Kafka**
+
+Kafka guarantees message ordering within a partition. However, when an event handler triggers a `start_workflow` action, workflow creation is processed concurrently; meaning two messages from the same partition may result in workflows starting in a different order than the messages arrived.
+
+If ordering matters for your use case:
+
+- Use a consistent partition key for messages that must be processed in order, so they land on the same partition.
+- Use `idempotencyKey` on the `start_workflow` action to prevent duplicate workflows from being created if a message is redelivered.
+- Handle ordering inside the workflow; pass a sequence number or timestamp in the event payload and use it within the workflow to detect and respond to out-of-order execution.

--- a/docs/developer-guides/event-handler.mdx
+++ b/docs/developer-guides/event-handler.mdx
@@ -89,6 +89,34 @@ The following expressions can be used in **condition** with the indicated result
 | $.version > 10 | false | 
 | $.metadata.length == 300 | true | 
 
+### Referencing payload fields
+
+The variable substitution syntax `${fieldName}` lets you pass values from the incoming message payload into your action parameters. Fields are referenced by their key name; nested fields use dot notation.
+
+For example, given this message payload:
+
+```json
+{
+  "workflowId": "4c87e4f6-06b7-11f1-8cfa-e2ee94ec02d4",
+  "waitTaskRefName": "wait_for_lambda_ref",
+  "updateTask": true,
+  "data": {
+    "field_1": "value_1",
+    "field_2": "value_2"
+  }
+}
+```
+
+The following references resolve as shown:
+
+| Reference | Resolved value | 
+| --------- | -------------- |
+| ${workflowId} | 4c87e4f6-06b7-11f1-8cfa-e2ee94ec02d4 | 
+| ${waitTaskRefName} | wait_for_lambda_ref | 
+| ${data.field_1} | value_1 | 
+
+The same fields are accessible in the `condition` expression using `$.fieldName` syntax (for example, `$.updateTask == true`).
+
 ## Configuring actions 
 
 Actions are executed only after the `condition` evaluates to `true`. Multiple actions can be triggered based on the events received. Below are the actions and their configuration details. 

--- a/docs/developer-guides/scheduling-workflows.mdx
+++ b/docs/developer-guides/scheduling-workflows.mdx
@@ -24,6 +24,8 @@ Examples include:
 * Scanning of S3 or Blob storage daily to verify compliance with policies.
 * Monitoring the health of a server, such as every 30 seconds.
 
+Non-admin users can only view and interact with schedules they have READ access to. Creators are automatically granted full access to schedules they create.
+
 ## Schedule parameters
 
 Configure these parameters when creating a schedule.
@@ -209,6 +211,33 @@ To get the scheduled workflow execution details as code in the UI, select the ar
 This will display the execution search data in cURL and JavaScript.
 
 <p align="center"><img src="/content/img/scheduler-execution-search-data-code.png" alt="Scheduler search execution search data in code" width="100%" height="auto"></img></p>
+
+## Troubleshooting schedules
+
+**Auto-pause on permission loss**
+
+Orkes Conductor automatically pauses a schedule if the schedule creator loses EXECUTE permission on the associated workflow. This is a security measure to prevent unauthorized workflow executions.
+
+**Identifying an auto-paused schedule**
+
+To confirm a schedule was paused due to a permission loss, retrieve the schedule using the API:
+
+```
+GET /api/scheduler/schedules/{name}
+```
+
+In the response, check the `pausedReason` field. If the schedule was auto-paused due to a security violation, the value will follow this format:
+
+```
+Security Error: <message>
+```
+
+**Resolving an auto-paused schedule**
+
+**To resume the schedule:**
+
+1. Restore EXECUTE permission on the workflow for the schedule's creator.
+2. Manually resume the schedule.
 
 <FAQStructuredData faqs={faqs} />
 

--- a/docs/developer-guides/using-workers.mdx
+++ b/docs/developer-guides/using-workers.mdx
@@ -119,10 +119,10 @@ Create a Python worker by adding a @worker_task decorator to a function.
 from conductor.client.worker.worker_task import worker_task
 
 @worker_task(task_definition_name='myTask')
-def greet(name: str) -> str:
-    return f'Hello {name}'
+def worker(name: str) -> str:
+    return f'hello, {name}'
 ```
-Check out the full sample worker project in Python: https://github.com/conductor-oss/conductor-apps/tree/main/python/developer-guides/using-workers
+Check out the full sample worker project in Python: https://github.com/conductor-oss/awesome-conductor-apps/tree/main/python/developer-guides/using-workers
 
 </TabItem>
 
@@ -142,7 +142,7 @@ public class Workers {
 }
 ```
 
-Check out the full sample worker project in Java: https://github.com/conductor-oss/conductor-apps/tree/main/java/developer-guides/using-workers
+Check out the full sample worker project in Java: https://github.com/conductor-oss/awesome-conductor-apps/tree/main/java/developer-guides/using-workers
 
 </TabItem>
 
@@ -163,14 +163,14 @@ const worker = {
 };
 ```
 
-Check out the full sample worker project in JavaScript: https://github.com/conductor-oss/conductor-apps/tree/main/javascript/developer-guides/using-workers
+Check out the full sample worker project in JavaScript: https://github.com/conductor-oss/awesome-conductor-apps/tree/main/javascript/developer-guides/using-workers
 
 </TabItem>
 
 <TabItem value="csharp" label="C#">
 
 ``` csharp
-[WorkerTask(taskType: "myTask", batchSize: 5, pollIntervalMs: 500, workerId: "csharp-worker")]
+[WorkerTask(taskType: "myTask", batchSize: 5, pollIntervalMs: 500, workerId: "sample-csharp-worker")]
 public static TaskResult MyTask(Conductor.Client.Models.Task task)
 {
     var inputData = task.InputData;
@@ -183,7 +183,7 @@ public static TaskResult MyTask(Conductor.Client.Models.Task task)
 }
 ```
 
-Check out the full sample worker project in C#: https://github.com/conductor-oss/conductor-apps/tree/main/csharp/developer-guides/using-workers
+Check out the full sample worker project in C#: https://github.com/conductor-oss/awesome-conductor-apps/tree/main/csharp/developer-guides/using-workers
 
 </TabItem>
 
@@ -203,7 +203,7 @@ func myTask(task *model.Task) (interface{}, error) {
 }
 ```
 
-Check out the full sample worker project in Go: https://github.com/conductor-oss/conductor-apps/tree/main/go/developer-guides/using-workers
+Check out the full sample worker project in Go: https://github.com/conductor-oss/awesome-conductor-apps/tree/main/go/developer-guides/using-workers
 
 
 </TabItem>
@@ -222,13 +222,20 @@ Run the Python worker by calling a TaskHandler.
 ``` python
 from conductor.client.automator.task_handler import TaskHandler
 from conductor.client.configuration.configuration import Configuration
+from conductor.client.configuration.settings.authentication_settings import AuthenticationSettings
+from worker import *
 
-task_handler = TaskHandler(configuration=Configuration())
+configuration = Configuration(
+    base_url='https://SERVER_URL',  # e.g., https://developer.orkescloud.com
+    authentication_settings=AuthenticationSettings(key_id='_CHANGE_ME_', key_secret='_CHANGE_ME_')
+)
+
+task_handler = TaskHandler(
+    configuration=configuration,
+    scan_for_annotated_workers=True
+)
 task_handler.start_processes()
-task_handler.join_processes()
 ```
-
-`task_handler.join_processes()` blocks the main thread indefinitely, keeping the worker running until the process is killed. To stop the worker gracefully (for example, in response to a shutdown signal), call `task_handler.stop_processes()` instead.
 
 </TabItem>
 
@@ -307,7 +314,7 @@ import (
 
 apiClient := client.NewAPIClient(
     settings.NewAuthenticationSettings(
-        KEY,
+        KEY_ID,
         SECRET,
     ),
     settings.NewHttpSettings(
@@ -315,7 +322,7 @@ apiClient := client.NewAPIClient(
 ))
 
 taskRunner = worker.NewTaskRunnerWithApiClient(apiClient)
-taskRunner.StartWorker("myTask", myTask, 1, time.Second*1)
+taskRunner.StartWorker("myTask", myTask, 1, time.Millisecond*200)
 ```
 
 </TabItem>

--- a/docs/getting-started/quickstart-2.mdx
+++ b/docs/getting-started/quickstart-2.mdx
@@ -145,7 +145,7 @@ def main():
     # Create the workflow definition.
     workflow = ConductorWorkflow(
         executor=executor,
-        name='myFirstWorkflow',
+        name='helloWorld',
         description='Workflow that greets a user. Uses a Switch task, HTTP task, and Simple task.',
         version=1
     )
@@ -153,7 +153,7 @@ def main():
     # Create the tasks.
     httpTask = HttpTask('get-user_ref', {'uri': 'https://randomuser.me/api/'})
     switchTask = SwitchTask('user-criteria_ref', '${get-user_ref.output.response.body.results[0].location.country}').switch_case(
-        'United States', SimpleTask('helloWorld', 'simple_ref').input(
+        'United States', SimpleTask('myTask', 'simple_ref').input(
             key='user', value='${get-user_ref.output.response.body.results[0].name.first}'))
 
     # Add the tasks to the workflow using `add` method or the `>>` operator.
@@ -166,7 +166,7 @@ def main():
 
     # Start the workflow.
     request = StartWorkflowRequest()
-    request.name = 'myFirstWorkflow'
+    request.name = 'helloWorld'
     request.version = 1
     id = executor.start_workflow(request)
     print(f"Started workflow {id}")
@@ -209,13 +209,13 @@ public class WorkflowAsCode {
 
         // Create the workflow definition.
         ConductorWorkflow<Object> workflow = new WorkflowBuilder<>(executor)
-                .name("myFirstWorkflow")
+                .name("helloWorld")
                 .version(1)
                 .description("Workflow that greets a user. Uses a Switch task, HTTP task, and Simple task.")
                 .add(new Http("get-user_ref").url("https://randomuser.me/api/"))
                 // This switch task will execute the "helloWorld" task if the user's country is "United States"
                 .add(new Switch("user-criteria_ref", "${get-user_ref.output.response.body.results[0].location.country}")
-                        .switchCase("United States", new SimpleTask("helloWorld", "simple_ref")
+                        .switchCase("United States", new SimpleTask("myTask", "simple_ref")
                                 .input("user", "${get-user_ref.output.response.body.results[0].name.first}")))
                 .build();
 
@@ -262,7 +262,7 @@ const executor = new WorkflowExecutor(client);
 
 // Create the workflow definition.
 const wf = {
-  name: "myFirstWorkflow",
+  name: "helloWorld",
   version: 1,
   description:
     "Workflow that greets a user. Uses a Switch task, HTTP task, and Simple task.",
@@ -273,7 +273,7 @@ const wf = {
       "${get-user_ref.output.response.body.results[0].location.country}",
       {
         "United States": [
-          simpleTask("simple_ref", "helloWorld", {
+          simpleTask("simple_ref", "myTask", {
             user: "${get-user_ref.output.response.body.results[0].name.first}",
           }),
         ],
@@ -320,13 +320,13 @@ var executor = new WorkflowExecutor(conf);
 
 // Create the workflow definition.
 var workflow = new ConductorWorkflow()
-        .WithName("myFirstWorkflow")
+        .WithName("helloWorld")
         .WithDescription("Workflow that greets a user. Uses a Switch task, HTTP task, and Simple task.")
         .WithVersion(1)
         .WithTask(new HttpTask("get-user_ref", new HttpTaskSettings { uri = "https://randomuser.me/api/" }))
         .WithTask(new SwitchTask("user-criteria_ref", "${get-user_ref.output.response.body.results[0].location.country}")
             .WithDecisionCase("United States",
-                [new SimpleTask("helloWorld", "simple_ref").WithInput("user", "${get-user_ref.output.response.body.results[0].name.first}")]));
+                [new SimpleTask("myTask", "simple_ref").WithInput("user", "${get-user_ref.output.response.body.results[0].name.first}")]));
 
 // Register the workflow with overwrite = true.
 executor.RegisterWorkflow(
@@ -378,13 +378,13 @@ var (
 func main() {
 	// Create the workflow definition.
 	wf := workflow.NewConductorWorkflow(workflowExecutor).
-		Name("myFirstWorkflowGo").
+		Name("helloWorld").
 		Version(1).
 		Description("Workflow that greets a user. Uses a Switch task, HTTP task, and Simple task.")
 
 	httpTask := workflow.NewHttpTask("get-user_ref", &workflow.HttpInput{Uri: "https://randomuser.me/api/"})
 	switchTask := workflow.NewSwitchTask("user-criteria_ref", "${get-user_ref.output.response.body.results[0].location.country}").
-		SwitchCase("United States", workflow.NewSimpleTask("helloWorld", "simple_ref").Input("user", "${get-user_ref.output.response.body.results[0].name.first}"))
+		SwitchCase("United States", workflow.NewSimpleTask("myTask", "simple_ref").Input("user", "${get-user_ref.output.response.body.results[0].name.first}"))
 
 	wf.Add(httpTask)
 	wf.Add(switchTask)
@@ -428,7 +428,7 @@ To connect your workflow-as-code project, you must again use an application in C
 
 ``` java
 ApiClient client = ApiClient.builder()
-        .basePath("[https://SERVER_URL/api](https://SERVER_URL/api)") // e.g., “[https://developer.orkescloud.com/api](https://developer.orkescloud.com/api)” for Developer Edition
+        .basePath(“https://SERVER_URL/api”) // e.g., https://developer.orkescloud.com/api for Developer Edition
         .credentials("_CHANGE_ME_", "_CHANGE_ME_")
         .build();
 ```
@@ -444,6 +444,10 @@ Let’s give your first workflow a test run.
 
 :::tip
 Before running the workflow, make sure that your *myTask* worker is actively polling the Conductor server. Otherwise, go back and [start your worker](write-workers#start-the-worker) again.
+:::
+
+:::caution Third-party API dependency
+This workflow fetches data from `randomuser.me`, a public API that can occasionally return empty results. If the Switch task receives an empty response, `switchCaseValue` resolves to undefined and the workflow always routes to `defaultCase`—meaning `myTask` never executes. If your workflow completes without running `myTask`, retry the execution and check the HTTP task's output in the execution details to confirm the API returned a valid result.
 :::
 
 <Tabs groupId="workflow-method">

--- a/docs/reference-docs/operators/fork-join.mdx
+++ b/docs/reference-docs/operators/fork-join.mdx
@@ -28,7 +28,7 @@ The [Join](./join) task will run after the forked tasks. Configure the Join task
 
 | Parameter  | Description                                                                                                      | Required/ Optional |
 | ---------- | ---------------------------------------------------------------------------------------------------------------- | ------------------ |
-| joinOn     | A list of task reference names that the Join task will wait for completion before proceeding with the next task. <br/><br/>**Notes**: When a Join task is used after a [Switch](https://orkes.io/content/reference-docs/operators/switch) task, the Join task can complete when the Switch task completes, even if the tasks within the switch branches have not finished. To handle this, add a task such as [Set Variable](https://orkes.io/content/reference-docs/operators/set-variable) at the end of the outermost Switch task and configure the Join task to join on that task. This ensures the Join task waits until all switch branch execution is complete before the workflow continues. | Required.          |
+| joinOn     | A list of task reference names that the Join task will wait for completion before proceeding with the next task. | Required.          |
 | expression | The join script, which controls how the Join task completes if specified.                                        | Optional.          |
 
 ## Task configuration
@@ -81,6 +81,11 @@ The Fork task does not produce output. The Join task returns a map containing th
 4. Select the Join task and configure its settings to complete the fork/join operations.
 
 <p><img src="/content/img/ui-guide-fork-join.png" alt="Screenshot of Fork/Join Task in Orkes Conductor"/></p>
+
+:::info Notes
+- When a Join task is used after a [Switch](/content/reference-docs/operators/switch) task, the Join task can complete when the Switch task completes, even if the tasks within the switch branches have not finished. To handle this, add a task such as [Set Variable](https://orkes.io/content/reference-docs/operators/set-variable) at the end of the outermost Switch task and configure the Join task to join on that task. This ensures the Join task waits until all switch branch execution is complete before the workflow continues.
+- If a fork branch containing a [Sub Workflow task](/content/reference-docs/operators/sub-workflow) fails, sibling tasks in other branches are cancelled and the parent workflow moves to a FAILED state. When the failed sub-workflow is retried, all cancelled sibling tasks are automatically rescheduled and the parent workflow resumes to RUNNING.
+:::
 
 ## Examples
 


### PR DESCRIPTION
Remove the lengthy note from the 'joinOn' parameter table cell and place it into an 'info' callout for improved readability. Also add a new note describing behavior when a fork branch contains a Sub Workflow task that fails (sibling tasks are cancelled and are rescheduled when the failed sub-workflow is retried). Minor formatting cleanup of the Fork/Join docs page.