### PR TITLE
docs(home): improve tagline and card copy for faster user orientation

### DIFF
--- a/docs/what-is-orkes-conductor.mdx
+++ b/docs/what-is-orkes-conductor.mdx
@@ -20,7 +20,7 @@ import {
 
 <main className={`mainContainer container`}>
 <NewToConductorSection
-  title="Build AI Agents and Workflows: Scale With Confidence"
+  title="Build AI Agents and Workflows That Survive Failures"
   description={
     <div>
       Orkes Conductor is the battle-tested orchestration platform rooted in open-source used to build workflows and AI agents that survive failures. Write workers in any language, define your logic in code or JSON, and get built-in durable execution, observability, and control at any scale.
@@ -35,19 +35,19 @@ import {
     {
       title: "New to Conductor?",
       description:
-        "Install the SDK, connect to your cluster, and run your first workflow. Our quickstarts walk you through the core concepts step by step.",
+        "Install the SDK, run your first workflow in under 10 minutes, and learn the core concepts: tasks, workers, and workflow definitions.",
       to: "/content/quickstarts",
     },
     {
       title: "Building something?",
       description:
-        "Jump straight to SDK docs, API reference, or task type definitions. Everything you need to build and ship a production workflow.",
+        "Find the task type, API endpoint, or SDK method you need. Reference docs for HTTP, Switch, Fork/Join, LLM tasks, and more.",
       to: "/content/category/sdks",
     },
     {
       title: "Exploring AI workflows?",
       description:
-        "Use LLM tasks, agentic patterns, and MCP integrations to build AI agents that are reliable, observable, and easy to debug.",
+        "Build AI agents with LLM tasks, tool calling via MCP, and human-in-the-loop approvals, all within a durable, observable workflow.",
       to: "/ai-orchestration",
     },
   ]}


### PR DESCRIPTION
## Summary

- **Tagline**: Changed \"Build AI Agents and Workflows: Scale With Confidence\" to \"Build AI Agents and Workflows That Survive Failures\" — moves the most distinctive claim up to headline level
- **Card 1 (New to Conductor?)**: Added time anchor (\"under 10 minutes\") and named the actual concepts users will learn (tasks, workers, workflow definitions)
- **Card 2 (Building something?)**: Replaced vague copy with concrete task type names (HTTP, Switch, Fork/Join, LLM tasks) so developers scanning for specific features get an immediate signal
- **Card 3 (Exploring AI workflows?)**: Replaced \"reliable, observable, and easy to debug\" with concrete features (tool calling via MCP, human-in-the-loop approvals) that resonate with AI builders
