### PR TITLE
Fix meta description length for source-control category

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -1047,7 +1047,7 @@ const sidebars = {
                                 type: 'generated-index',
                                 title: 'Source Control',
                                 slug: '/category/integrations/source-control',
-                                description: 'Learn how to connect source control platforms to Conductor workflows.',
+                                description: 'Learn how to connect source control platforms and repositories to Conductor workflows.',
                             },
                             items: [
                                 {


### PR DESCRIPTION
## Summary
- The Deploy Docs Site CI job has been failing on every push to `docs_site_revamp` since PR #1099, at the `audit:docs` step, because the "Source Control" integrations category's generated-index description was 69 characters (the audit requires a 70-char minimum).
- One-line fix: lengthened the description while keeping it accurate.

## Test plan
- [x] Ran `npm run build && npm run audit:docs` locally with the same `DOCS_BASE_URL`/`DOCS_SITE_URL` env vars as CI — audit passed (514 HTML pages checked, 0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)