### PR TITLE
Dedupe OSS reference pages and surface missing guides in nav

### DIFF
--- a/docs/developer-guides/workflows.mdx
+++ b/docs/developer-guides/workflows.mdx
@@ -37,14 +37,14 @@ Keep domain logic in workers or services when it is complex, private, or heavily
 | Tasks | Performs work or controls execution | [Tasks in Workflows](/content/developer-guides/tasks) |
 | Workers | Runs custom code outside Conductor for SIMPLE tasks | [Writing Workers](/content/developer-guides/using-workers) |
 | Operators | Branches, loops, joins, waits, starts sub-workflows, and terminates flows | [Operators Reference](/content/category/reference-docs/operators) |
-| Outputs | Shapes the final workflow result | [Workflow Definition Reference](/content/reference-docs/workflow-definition) |
+| Outputs | Shapes the final workflow result | [Workflow Definition Reference](/content/reference-docs/api/metadata/creating-workflow-definition) |
 | Versions | Controls which definition future executions use | [Versioning Workflows](/content/developer-guides/versioning-workflows) |
 | Triggers | Starts or resumes workflows from APIs, schedules, events, webhooks, or signals | [Executing Workflows](/content/developer-guides/running-workflows) |
 | Controls | Adds retries, timeouts, rate limits, schemas, masking, and permissions | [Handling Failures](/content/error-handling) |
 
 ## Workflow definition
 
-A workflow definition is the portable execution format Conductor stores and runs. You only need to understand the shape here; use the [Workflow Definition Reference](/content/reference-docs/workflow-definition) for the full schema.
+A workflow definition is the portable execution format Conductor stores and runs. You only need to understand the shape here; use the [Workflow Definition Reference](/content/reference-docs/api/metadata/creating-workflow-definition) for the full schema.
 
 ```json
 {
@@ -100,4 +100,4 @@ Agentic workflows use LLMs, tools, memory, retrieval, human review, and determin
 - [Tasks in Workflows](/content/developer-guides/tasks)
 - [Versioning Workflows](/content/developer-guides/versioning-workflows)
 - [Executing Workflows](/content/developer-guides/running-workflows)
-- [Workflow Definition Reference](/content/reference-docs/workflow-definition)
+- [Workflow Definition Reference](/content/reference-docs/api/metadata/creating-workflow-definition)

--- a/shared-docs-map.json
+++ b/shared-docs-map.json
@@ -106,7 +106,6 @@
       "docId": "ai-cookbook/token-efficiency",
       "route": "ai-orchestration/token-efficiency"
     },
-
     {
       "source": "devguide/cookbook/index.md",
       "docId": "cookbook/index",
@@ -147,7 +146,6 @@
       "docId": "cookbook/dynamic-workflows",
       "route": "cookbook/dynamic-workflows"
     },
-
     {
       "source": "documentation/clientsdks/index.md",
       "docId": "sdks/sdk-index",
@@ -188,7 +186,6 @@
       "docId": "sdks/rust",
       "route": "sdks/rust"
     },
-
     {
       "source": "documentation/api/index.md",
       "docId": "reference-docs/api/index",
@@ -229,28 +226,6 @@
       "docId": "reference-docs/api/event-handlers",
       "route": "reference-docs/api/event-handlers"
     },
-    {
-      "source": "documentation/api/taskdomains.md",
-      "docId": "reference-docs/api/task-domains",
-      "route": "reference-docs/api/task-domains"
-    },
-
-    {
-      "source": "documentation/configuration/workflowdef/index.md",
-      "docId": "reference-docs/workflow-definition",
-      "route": "reference-docs/workflow-definition"
-    },
-    {
-      "source": "documentation/configuration/taskdef.md",
-      "docId": "reference-docs/task-definition",
-      "route": "reference-docs/task-definition"
-    },
-    {
-      "source": "documentation/configuration/eventhandlers.md",
-      "docId": "reference-docs/event-handlers",
-      "route": "reference-docs/event-handlers"
-    },
-
     {
       "source": "documentation/configuration/workflowdef/operators/switch-task.md",
       "docId": "reference-docs/operators/switch",
@@ -311,7 +286,6 @@
       "docId": "reference-docs/operators/wait",
       "route": "reference-docs/operators/wait"
     },
-
     {
       "source": "documentation/configuration/workflowdef/systemtasks/index.md",
       "docId": "reference-docs/system-tasks/index",
@@ -365,10 +339,11 @@
     "documentation/advanced/externalpayloadstorage.md": "https://docs.conductor-oss.org/documentation/advanced/externalpayloadstorage",
     "documentation/advanced/file-storage.md": "https://docs.conductor-oss.org/documentation/advanced/file-storage",
     "documentation/api/startworkflow.md": "reference-docs/api/workflow/start-workflow-execution",
-    "documentation/configuration/eventhandlers.md": "reference-docs/event-handlers",
-    "documentation/configuration/taskdef.md": "reference-docs/task-definition",
-    "documentation/configuration/workflowdef/index.md": "reference-docs/workflow-definition",
+    "documentation/configuration/eventhandlers.md": "developer-guides/event-handler",
+    "documentation/configuration/taskdef.md": "reference-docs/api/metadata/creating-task-definitions",
+    "documentation/configuration/workflowdef/index.md": "reference-docs/api/metadata/creating-workflow-definition",
     "documentation/configuration/workflowdef/operators/index.md": "category/reference-docs/operators",
-    "devguide/how-tos/event-bus.md": "eventing"
+    "devguide/how-tos/event-bus.md": "eventing",
+    "documentation/api/taskdomains.md": "developer-guides/task-to-domain"
   }
 }

--- a/sidebars.js
+++ b/sidebars.js
@@ -107,6 +107,11 @@ const sidebars = {
                         'developer-guides/integration-with-cicd',
                         'developer-guides/secrets-in-conductor',
                         'developer-guides/using-environment-variables',
+                        {
+                            type: 'doc',
+                            id: 'developer-guides/schema-validation',
+                            label: 'Schema Validation',
+                        },
                         'developer-guides/error-handling',
                     ],
                 },
@@ -120,12 +125,32 @@ const sidebars = {
                             id: 'developer-guides/passing-inputs-to-task-in-conductor',
                             label: 'Parameter Mapping',
                         },
+                        {
+                            type: 'doc',
+                            id: 'developer-guides/masking-parameters',
+                            label: 'Masking Parameters',
+                        },
+                        {
+                            type: 'doc',
+                            id: 'developer-guides/task-input-templates',
+                            label: 'Task Input Templates',
+                        },
                         'developer-guides/caching-task-outputs',
                         'developer-guides/rate-limits',
                         'developer-guides/using-workers',
                         'developer-guides/scaling-workers',
                         'developer-guides/task-to-domain',
                     ],
+                },
+                {
+                    type: 'doc',
+                    id: 'developer-guides/using-ai-prompts',
+                    label: 'Creating AI Prompts',
+                },
+                {
+                    type: 'doc',
+                    id: 'developer-guides/orchestrating-human-tasks',
+                    label: 'Human Task Orchestration',
                 },
                 {
                     type: 'category',
@@ -171,7 +196,6 @@ const sidebars = {
                         { type: 'doc', id: 'developer-guides/webhook-integration', label: 'Webhooks' },
                         { type: 'doc', id: 'reference-docs/system-tasks/wait-for-webhook', label: 'Wait for Webhook Task' },
                         { type: 'doc', id: 'developer-guides/event-handler', label: 'Event Handlers' },
-                        { type: 'doc', id: 'reference-docs/event-handlers', label: 'Event Handler Reference' },
                     ],
                 },
                 {
@@ -290,7 +314,6 @@ const sidebars = {
         { type: 'doc', id: 'cookbook/microservice-orchestration', label: 'Microservice orchestration' },
         { type: 'doc', id: 'cookbook/dynamic-parallelism', label: 'Dynamic parallelism' },
         { type: 'doc', id: 'cookbook/wait-and-timers', label: 'Wait and timer patterns' },
-        { type: 'doc', id: 'developer-guides/orchestrating-human-tasks', label: 'Human in the loop' },
         { type: 'doc', id: 'cookbook/task-timeouts-and-retries', label: 'Task timeouts and retries' },
         { type: 'doc', id: 'cookbook/workflow-scheduling', label: 'Scheduled workflows' },
         { type: 'doc', id: 'cookbook/dynamic-workflows', label: 'Dynamic workflows as code' },
@@ -397,8 +420,6 @@ const sidebars = {
             className: 'leftMenuHeader',
             items: [
                 'reference-docs/worker-task',
-                { type: 'doc', id: 'reference-docs/workflow-definition', label: 'Workflow Definition' },
-                { type: 'doc', id: 'reference-docs/task-definition', label: 'Task Definition' },
                 {
                     type: 'category',
                     label: 'Operators',
@@ -480,7 +501,6 @@ const sidebars = {
                 { type: 'doc', id: 'sdks/authentication', label: 'Authentication' },
                 { type: 'doc', id: 'reference-docs/api/bulk', label: 'Bulk' },
                 { type: 'doc', id: 'reference-docs/api/files', label: 'Files' },
-                { type: 'doc', id: 'reference-docs/api/task-domains', label: 'Task Domains' },
                 {
                     type: 'category',
                     label: 'Metadata',


### PR DESCRIPTION
## Summary
- Removes 4 OSS-imported reference pages that duplicated content already covered better by an existing Orkes-owned page, redirecting any internal OSS links via `shared-docs-map.json` aliases so nothing 404s:
  - `reference-docs/workflow-definition` → `reference-docs/api/metadata/creating-workflow-definition`
  - `reference-docs/task-definition` → `reference-docs/api/metadata/creating-task-definitions`
  - `reference-docs/event-handlers` → `developer-guides/event-handler`
  - `reference-docs/api/task-domains` → `developer-guides/task-to-domain`
- Fixes 3 hardcoded links in `docs/developer-guides/workflows.mdx` that pointed at the now-removed `reference-docs/workflow-definition`.
- Adds 4 previously nav-omitted pages to the Guides sidebar (they built fine but weren't reachable from any menu): Schema Validation, Masking Parameters, Task Input Templates, Creating AI Prompts.
- Moves `developer-guides/orchestrating-human-tasks` (Human Task Orchestration) out of the Cookbook section into Guides — it's an Orkes-authored dev guide, not an OSS-backed recipe.

## Test plan
- [x] Confirmed no remaining hardcoded links to any of the 4 removed routes anywhere in `docs/`
- [x] Confirmed each removed route has an existing sidebar-wired replacement, not a dangling reference
- [ ] Reviewer spot-check of nav placement for the newly surfaced guides

🤖 Generated with [Claude Code](https://claude.com/claude-code)