### PR TITLE
Stop OSS from overwriting Orkes pages, remove enterprise-unavailable tasks

### DIFF
--- a/docs/agentic-workflow-engine.mdx
+++ b/docs/agentic-workflow-engine.mdx
@@ -39,7 +39,6 @@ This boundary keeps the agent flexible while making the work recoverable. The mo
 - [Production Agent Architecture](/content/ai-orchestration/production-agent-architecture) shows how to separate reasoning from durable execution.
 - [Failure Semantics](/content/ai-orchestration/failure-semantics) shows how to test crashes, retries, timeouts, and recovery behavior.
 - [Durable Agents](/content/ai-orchestration/durable-agents) explains persisted state, long waits, compensation, and replay.
-- [MCP Integration](/content/ai-orchestration/mcp-integration) shows how to make tool calls durable and auditable.
 - [Build Your First AI Agent](/content/ai-orchestration/first-ai-agent) walks through the first runnable agent workflow.
 
 ## Why workflows are code-native, not JSON-only

--- a/docs/developer-guides/ai-orchestration.mdx
+++ b/docs/developer-guides/ai-orchestration.mdx
@@ -1,77 +1,90 @@
 ---
 slug: "/ai-orchestration"
-description: "Build agentic workflows with Orkes Conductor. Use LLM tasks, AI integrations, and multi-agent patterns to orchestrate reliable AI applications at scale."
+description: "AI agent orchestration and LLM orchestration with Conductor — LLM tasks, human-in-the-loop approval, dynamic workflows, and vector database workflows."
 ---
 
-# AI Orchestration 
+# AI Cookbook
 
-Orkes Conductor provides features to build and orchestrate AI-powered applications using LLMs and vector databases. From simple LLM orchestration tasks to complex agentic AI orchestration where decisions are made dynamically based on model output, you can design, govern, and run AI workflows at scale.
+Conductor is not an AI framework. It is a durable execution engine that provides AI agent orchestration and LLM orchestration by solving the hard infrastructure problems that AI agents create: long-running processes, unreliable external calls, tool use, human-in-the-loop approval, structured output, and the need to survive failures across any of these steps. Conductor makes every agent a durable agent — one that survives crashes, retries, and infrastructure failures without losing progress.
 
-Key features include:
 
-* **AI Tasks**: Use predefined system tasks to generate text, create embeddings, and retrieve results from vector databases.
-* **AI/LLM and Vector Database Integrations**: Connect to multiple AI models and vector databases in a secure, governed way.
-* **AI Prompt Studio**: Create, refine, test, and govern prompt templates for AI models.
+## The problem agents create
 
-You can use these features to build:
+An AI agent is a long-running process that:
 
-* LLM orchestration pipelines
-* Agentic AI workflows
-* RAG (retrieval augmented generation) systems
-* LLM-powered chatbots
+1. **Calls an LLM** to decide what to do next.
+2. **Calls tools** (APIs, databases, other services) to take action.
+3. **Waits** for external events, human approval, or time-based delays.
+4. **Loops** through plan/act/observe cycles until a goal is reached.
+5. **Returns structured output** to the caller or another system.
 
-## AI and LLM tasks
+Each of these steps can fail, take minutes to hours, or require intervention. Running this in a single process means any crash loses all progress. Running it in a queue means building your own state machine, retry logic, and observability. Conductor provides all of this out of the box.
 
-Orkes Conductor provides a variety of AI tasks that can execute common logic without the need to write code. Depending on the task type, these tasks may require an AI/LLM integration, a vector database integration, or an AI prompt.
 
-| AI Task     | Description                        |Prerequisites                 |
-|------------------- | ---------------------------------- |----------------------------- |
-| [LLM Text Complete](/reference-docs/ai-tasks/llm-text-complete) | Generate text from an LLM based on a defined prompt.                                  | <ul><li>Integrate an AI model</li><li>Create an AI prompt</li></ul>                     |
-| [LLM Generate Embeddings](/reference-docs/ai-tasks/llm-generate-embeddings) | Generate text embeddings.                                          | <ul><li>Integrate an AI model</li></ul> |
-| [LLM Store Embeddings](/reference-docs/ai-tasks/llm-store-embeddings) | Store text embeddings in a vector database.                                   | <ul><li>Integrate an AI model</li> <li>Integrate a vector database</li></ul>            |
-| [LLM Get Embeddings](/reference-docs/ai-tasks/llm-get-embeddings) | Retrieve data from a vector database.                                            | <ul><li>Integrate a vector database</li></ul> |
-| [LLM Index Document](/reference-docs/ai-tasks/llm-index-document)  | Chunk, generate, and store text embeddings in a vector database.                    | <ul><li>Integrate an AI model</li> <li>Integrate a vector database</li></ul>            |
-| [LLM Get Document](/reference-docs/ai-tasks/llm-get-document)  | Retrieve text or JSON content from a URL.                                           | NA                  |
-| [LLM Index Text](/reference-docs/ai-tasks/llm-index-text)      | Generate and store text embeddings in a vector database.                              | <ul><li>Integrate an AI model</li> <li>Integrate a vector database</li></ul>            |
-| [LLM Search Index](/reference-docs/ai-tasks/llm-search-index)  | Retrieve data from a vector database based on a search query.                           | <ul><li>Integrate an AI model</li> <li>Integrate a vector database</li></ul>            |
-| [LLM Chat Complete](/reference-docs/ai-tasks/llm-chat-complete) | Generate text from an LLM based on a user query and additional system/assistant instructions. | <ul><li>Integrate an AI model</li><li>Create an AI prompt (Optional)</li></ul> |
-| [Chunk Text](/reference-docs/ai-tasks/chunk-text) | Divide text into smaller segments (chunks) based on the document type. | NA | 
-| [List Files](/reference-docs/ai-tasks/list-files) | Retrieve files from a specific storage location. | <ul><li>Integrate cloud providers for private files</li></ul> | 
-| [Parse Document](/reference-docs/ai-tasks/parse-document) | Retrieves, parses,  and chunk documents from various storage locations. | <ul><li>Integrate cloud providers for private files</li></ul> | 
+## How it works
 
-## AI/LLM and vector database integrations
+```mermaid
+graph LR
+    A[Your Agent Code] -->|start workflow| B[Conductor Server]
+    B -->|schedule tasks| C[Task Queue]
+    C -->|poll| D[LLM Worker]
+    C -->|poll| E[Tool Worker]
+    B -->|persist every step| G[(Durable Storage)]
+    B -->|pause & resume| H[HUMAN / WAIT]
+    H -->|API call or signal| B
+    D -->|result| B
+    E -->|result| B
+```
 
-Orkes Conductor integrates with the following AI/LLM providers: 
+Your agent code starts a workflow. Conductor schedules each step as a task, persists every input and output to durable storage, and manages retries, timeouts, and pauses. Workers (LLM calls, tool calls) poll for tasks, execute them, and return results. If any worker or the server itself crashes, execution resumes from the last completed step.
 
-- [Ollama](https://orkes.io/content/integrations/ai-llm/ollama)
-- [Azure + OpenAI](https://orkes.io/content/integrations/ai-llm/azure-open-ai)
-- [OpenAI](https://orkes.io/content/integrations/ai-llm/open-ai)
-- [Perplexity](https://orkes.io/content/integrations/ai-llm/perplexity)
-- [Grok](https://orkes.io/content/integrations/ai-llm/grok)
-- [Cohere​​](https://orkes.io/content/integrations/ai-llm/cohere)
-- [Mistral](https://orkes.io/content/integrations/ai-llm/mistral)
-- [Anthropic Claude](https://orkes.io/content/integrations/ai-llm/anthropic-claude)
-- [Google Vertex AI](https://orkes.io/content/integrations/ai-llm/vertex-ai)
-- [Google Gemini AI](https://orkes.io/content/integrations/ai-llm/google-gemini-ai)
-- [Hugging Face](https://orkes.io/content/integrations/ai-llm/hugging-face)
-- [AWS Bedrock Anthropic](https://orkes.io/content/integrations/ai-llm/aws-bedrock-anthropic)
-- [AWS Bedrock Cohere](https://orkes.io/content/integrations/ai-llm/aws-bedrock-cohere)
-- [AWS Bedrock Titan](https://orkes.io/content/integrations/ai-llm/aws-bedrock-titan)
 
-For vector databases, supported providers include:
+## How Conductor's primitives map to agent patterns
 
-- [Pinecone](https://orkes.io/content/integrations/vector-databases/pinecone)
-- [Weaviate](https://orkes.io/content/integrations/vector-databases/weaviate)
-- [Postgres Vector Database (pgvector)](https://orkes.io/content/integrations/vector-databases/postgres-vector-database)
-- [Mongo Vector Database (MongoDB Atlas)](https://orkes.io/content/integrations/vector-databases/mongo-vector-database)
+| Agent pattern | Conductor primitive | What happens mechanically |
+|---|---|---|
+| **LLM call** | `LLM_CHAT_COMPLETE` / `LLM_TEXT_COMPLETE` system task | Native LLM task. Configure provider and model as parameters. Retried on failure. Prompt, response, and token usage persisted. Supports built-in tools: web search, code execution, file search, extended thinking. |
+| **Embeddings** | `LLM_GENERATE_EMBEDDINGS` system task | Generate vector embeddings using any configured provider. Output stored and passed to downstream tasks. |
+| **RAG / semantic search** | `LLM_INDEX_TEXT` + `LLM_SEARCH_INDEX` system tasks | Index documents and run semantic search against Pinecone, pgvector, or MongoDB Atlas. No external RAG framework needed. |
+| **Wait for human approval** | `HUMAN` task | Workflow pauses. Remains `IN_PROGRESS` in persistent storage. Resumes when the Task Update API is called with approval/rejection. Survives deploys. |
+| **Wait for external event** | `WAIT` task (time-based) or `HUMAN` task with event handler | Durable pause. Timer or signal resolution survives server restarts. |
+| **Wait for webhook** | `HUMAN` task + webhook endpoint | External system calls the Task Update API with payload. Workflow resumes with that payload as task output. |
+| **Plan/act/observe loop** | `DO_WHILE` operator | Loop until a condition is met. Each iteration is a persisted step. The loop counter and state survive failures. |
+| **Dynamic tool selection** | `DYNAMIC` task or `DYNAMIC_FORK` | The LLM output determines which task(s) to run next. Conductor resolves the task type at runtime. |
+| **Multi-agent / sub-agent** | `SUB_WORKFLOW` task | Spawn a child agent as a sub-workflow. Parent waits for completion. Failure in a child can trigger compensation in the parent. Full observability across the entire agent tree. |
+| **Rollback on failure** | `failureWorkflow` + compensation pattern | When an agent fails after taking real-world actions, a failure workflow runs compensating tasks (undo API calls, send notifications, release resources). |
+| **Structured output** | Workflow `outputParameters` | Map task outputs to a structured JSON response using Conductor's expression syntax. |
+| **Expose as API** | Conductor REST API: `POST /api/workflow/{name}` | Any workflow is callable via HTTP. Start synchronously or asynchronously. Get structured output back. |
+| **Expose as MCP tool** | MCP Gateway integration | Register any workflow as an MCP tool via the MCP Gateway. External agents and LLMs can discover and invoke it, receiving structured output. |
 
-Each integration is configured at the cluster level with provider credentials and access to models/indexes. Once configured, the integration and its models are available to reference in AI tasks within the workflows, but only for applications or groups that have been explicitly granted access via RBAC.
 
-## AI Prompt Studio
+## What you'd have to build without Conductor
 
-Orkes Conductor includes a dedicated Prompt Studio for creating, testing, and refining prompt templates. Prompts created here are reusable across any workflow that contains an LLM Text Complete or LLM Chat Complete task.
+If you run agents on a framework like LangChain, CrewAI, or LangGraph without a durable execution backend, you are responsible for:
 
-Prompts support passing dynamic variables using `${variable_name}` syntax. At runtime, these variables are resolved from workflow inputs or the outputs of upstream tasks, allowing a single prompt template to serve different contexts without modification.
+- **State persistence** &mdash; Checkpointing agent progress so crashes don't restart from zero.
+- **Retry logic** &mdash; Retrying failed LLM and tool calls with backoff, deduplication, and timeout handling.
+- **Human-in-the-loop** &mdash; Building a pause/resume mechanism that survives process restarts and deploys.
+- **Compensation** &mdash; Rolling back side effects (sent emails, created records, charged payments) when a downstream step fails.
+- **Observability** &mdash; Logging every LLM prompt, response, tool call, and decision in a queryable, auditable format.
+- **Multi-agent coordination** &mdash; Managing parent-child lifecycle, failure propagation, and shared state across sub-agents.
+- **Scalability** &mdash; Distributing work across multiple worker processes and scaling them independently.
+
+Conductor provides all of this as infrastructure. Your agent code focuses on the logic — what to ask the LLM, which tools to call, what to do with the results.
+
+
+## Next steps
+
+- **[Build Your First AI Agent](/content/ai-orchestration/first-ai-agent)** &mdash; Step-by-step: discover MCP tools, call an LLM, execute, add human approval, make it autonomous. 5 minutes.
+- **[AI & LLM Recipes](/content/ai-orchestration/ai-llm-recipes)** &mdash; Ready-to-use recipes: chat completion, RAG, MCP agents, web search, code execution, coding agents, extended thinking, and more.
+- **[LLM Orchestration](/content/ai-orchestration/llm-orchestration)** &mdash; Native LLM providers, built-in tools, vector databases, and content generation.
+- **[Production Agent Architecture](/content/ai-orchestration/production-agent-architecture)** &mdash; The canonical reference architecture for a durable production agent. End-to-end pattern with every primitive mapped.
+- **[Failure Semantics for AI Agents](/content/ai-orchestration/failure-semantics)** &mdash; The exact failure contract: what happens under crashes, retries, duplicates, long waits, and partial side effects.
+- **[Why Conductor for Agents](/content/ai-orchestration/why-conductor)** &mdash; What Conductor gives you out of the box for agentic workflows.
+- **[Durable Agents](/content/ai-orchestration/durable-agents)** &mdash; What persists, what gets retried, and why JSON is AI-native.
+- **[Human-in-the-Loop](/content/ai-orchestration/human-in-the-loop)** &mdash; Pre-execution review, conditional approval, and LLM-as-judge patterns.
+- **[Dynamic Workflows](/content/ai-orchestration/dynamic-workflows)** &mdash; Agent loops, dynamic workflow generation, and tool use examples.
+- **[Token Efficiency](/content/ai-orchestration/token-efficiency)** &mdash; How durable execution saves tokens and reduces LLM costs.
 
 ## Learn more
 

--- a/docs/reference-docs/system-tasks/index.mdx
+++ b/docs/reference-docs/system-tasks/index.mdx
@@ -1,0 +1,78 @@
+---
+slug: "/category/reference-docs/system-tasks"
+description: "Overview of built-in system tasks in Conductor — HTTP, Event, Human, Wait, Inline, JSON JQ Transform, LLM orchestration, and more for durable workflow orchestration."
+---
+
+# System Tasks
+
+System tasks are built-in tasks that run on the Conductor server. They execute without external workers, allowing you to build workflows using common operations out of the box.
+
+## Available system tasks
+
+| System Task | Type | Description |
+| :--- | :--- | :--- |
+| [HTTP](/content/reference-docs/system-tasks/http) | `HTTP` | Call any HTTP/REST endpoint. Supports GET, POST, PUT, DELETE with headers, body, and connection/read timeouts. |
+| [Inline](/content/reference-docs/system-tasks/inline) | `INLINE` | Execute lightweight JavaScript or Python expressions server-side using GraalJS. Useful for data transformation, validation, and simple logic. |
+| [Event](/content/reference-docs/system-tasks/event) | `EVENT` | Publish events to external systems — Kafka, NATS, NATS Streaming, AMQP (RabbitMQ), SQS, or Conductor's internal queue. |
+| [Wait](/content/reference-docs/operators/wait) | `WAIT` | Pause workflow execution until a specified time, duration, or external signal. |
+| [Human](/content/reference-docs/operators/human) | `HUMAN` | Wait for an external signal, typically a human approval or manual action. The task stays `IN_PROGRESS` until completed via API. |
+| [JSON JQ Transform](/content/reference-docs/system-tasks/jq-transform) | `JSON_JQ_TRANSFORM` | Transform JSON data using [jq](https://jqlang.org/) expressions. Powerful for reshaping, filtering, and aggregating data. |
+| [JDBC](/content/reference-docs/system-tasks/jdbc) | `JDBC` | Execute SQL queries and updates against relational databases (MySQL, PostgreSQL, Oracle, etc.) with connection pooling and transaction management. |
+
+## Operators (flow control)
+
+These are also system tasks but control workflow execution flow rather than performing work:
+
+| Operator | Type | Description |
+| :--- | :--- | :--- |
+| [Fork/Join](/content/reference-docs/operators/fork-join) | `FORK_JOIN` | Execute tasks in parallel branches, then join. |
+| [Dynamic Fork](/content/reference-docs/operators/dynamic-fork) | `FORK_JOIN_DYNAMIC` | Dynamically create parallel branches at runtime. |
+| [Join](/content/reference-docs/operators/join) | `JOIN` | Wait for parallel branches to complete. |
+| [Switch](/content/reference-docs/operators/switch) | `SWITCH` | Conditional branching based on expressions or values. |
+| [Do While](/content/reference-docs/operators/do-while) | `DO_WHILE` | Loop over tasks until a condition is met. |
+| [Sub Workflow](/content/reference-docs/operators/sub-workflow) | `SUB_WORKFLOW` | Execute another workflow as a task. |
+| [Start Workflow](/content/reference-docs/operators/start-workflow) | `START_WORKFLOW` | Start another workflow asynchronously (fire-and-forget). |
+| [Set Variable](/content/reference-docs/operators/set-variable) | `SET_VARIABLE` | Set or update workflow-level variables. |
+| [Terminate](/content/reference-docs/operators/terminate) | `TERMINATE` | Terminate the workflow with a specified status. |
+| [Dynamic](/content/reference-docs/operators/dynamic) | `DYNAMIC` | Determine the task type to execute at runtime. |
+
+## AI & LLM tasks
+
+Conductor provides native AI system tasks with direct integration with 14+ LLM providers and 3 vector databases — no external frameworks or custom workers needed.
+
+### LLM
+
+| Task | Type | Description |
+| :--- | :--- | :--- |
+| Chat Completion | `LLM_CHAT_COMPLETE` | Multi-turn conversational AI with optional tool calling. Supports all major LLM providers. |
+| Text Completion | `LLM_TEXT_COMPLETE` | Single prompt completion. |
+
+**Supported providers:** Anthropic (Claude), OpenAI (GPT), Azure OpenAI, Google Gemini, AWS Bedrock, Mistral, Cohere, HuggingFace, Ollama, Perplexity, Grok (xAI), StabilityAI, and more. Switch providers by changing a configuration parameter — no code changes required.
+
+### Embeddings & Vector Search
+
+| Task | Type | Description |
+| :--- | :--- | :--- |
+| Generate Embeddings | `LLM_GENERATE_EMBEDDINGS` | Convert text to vector embeddings. |
+| Store Embeddings | `LLM_STORE_EMBEDDINGS` | Store pre-computed embeddings in a vector database. |
+| Index Text | `LLM_INDEX_TEXT` | Store text with auto-generated embeddings in a vector database. |
+| Search Index | `LLM_SEARCH_INDEX` | Semantic search using a text query. |
+| Search Embeddings | `LLM_SEARCH_EMBEDDINGS` | Search using embedding vectors directly. |
+
+**Supported vector databases:** Pinecone, pgvector (PostgreSQL), and MongoDB Atlas Vector Search. These enable RAG (retrieval-augmented generation) pipelines as standard Conductor workflows.
+
+### Content Generation
+
+| Task | Type | Description |
+| :--- | :--- | :--- |
+| Generate Image | `GENERATE_IMAGE` | Generate images from text prompts. |
+| Generate Audio | `GENERATE_AUDIO` | Text-to-speech synthesis. |
+| Generate Video | `GENERATE_VIDEO` | Generate videos from text or image prompts (async). |
+| Generate PDF | `GENERATE_PDF` | Convert markdown to PDF documents. |
+
+## Deprecated
+
+| Task | Replacement |
+| :--- | :--- |
+| Lambda | Use [Inline](/content/reference-docs/system-tasks/inline) instead. |
+| Decision | Use [Switch](/content/reference-docs/operators/switch) instead. |

--- a/shared-docs-map.json
+++ b/shared-docs-map.json
@@ -47,11 +47,6 @@
       "route": "developer-guides/conductor-skills"
     },
     {
-      "source": "devguide/ai/index.md",
-      "docId": "developer-guides/ai-orchestration",
-      "route": "ai-orchestration"
-    },
-    {
       "source": "devguide/ai/first-ai-agent.md",
       "docId": "ai-cookbook/first-ai-agent",
       "route": "ai-orchestration/first-ai-agent"
@@ -65,11 +60,6 @@
       "source": "devguide/ai/llm-orchestration.md",
       "docId": "ai-cookbook/llm-orchestration",
       "route": "ai-orchestration/llm-orchestration"
-    },
-    {
-      "source": "devguide/ai/mcp-guide.md",
-      "docId": "ai-cookbook/mcp-integration",
-      "route": "ai-orchestration/mcp-integration"
     },
     {
       "source": "devguide/ai/production-agent-architecture.md",
@@ -225,106 +215,6 @@
       "source": "documentation/api/eventhandlers.md",
       "docId": "reference-docs/api/event-handlers",
       "route": "reference-docs/api/event-handlers"
-    },
-    {
-      "source": "documentation/configuration/workflowdef/operators/switch-task.md",
-      "docId": "reference-docs/operators/switch",
-      "route": "reference-docs/operators/switch"
-    },
-    {
-      "source": "documentation/configuration/workflowdef/operators/do-while-task.md",
-      "docId": "reference-docs/operators/do-while",
-      "route": "reference-docs/operators/do-while"
-    },
-    {
-      "source": "documentation/configuration/workflowdef/operators/dynamic-task.md",
-      "docId": "reference-docs/operators/dynamic",
-      "route": "reference-docs/operators/dynamic"
-    },
-    {
-      "source": "documentation/configuration/workflowdef/operators/dynamic-fork-task.md",
-      "docId": "reference-docs/operators/dynamic-fork",
-      "route": "reference-docs/operators/dynamic-fork"
-    },
-    {
-      "source": "documentation/configuration/workflowdef/operators/fork-task.md",
-      "docId": "reference-docs/operators/fork-join",
-      "route": "reference-docs/operators/fork-join"
-    },
-    {
-      "source": "documentation/configuration/workflowdef/operators/join-task.md",
-      "docId": "reference-docs/operators/join",
-      "route": "reference-docs/operators/join"
-    },
-    {
-      "source": "documentation/configuration/workflowdef/operators/set-variable-task.md",
-      "docId": "reference-docs/operators/set-variable",
-      "route": "reference-docs/operators/set-variable"
-    },
-    {
-      "source": "documentation/configuration/workflowdef/operators/start-workflow-task.md",
-      "docId": "reference-docs/operators/start-workflow",
-      "route": "reference-docs/operators/start-workflow"
-    },
-    {
-      "source": "documentation/configuration/workflowdef/operators/sub-workflow-task.md",
-      "docId": "reference-docs/operators/sub-workflow",
-      "route": "reference-docs/operators/sub-workflow"
-    },
-    {
-      "source": "documentation/configuration/workflowdef/operators/terminate-task.md",
-      "docId": "reference-docs/operators/terminate",
-      "route": "reference-docs/operators/terminate"
-    },
-    {
-      "source": "documentation/configuration/workflowdef/systemtasks/human-task.md",
-      "docId": "reference-docs/operators/human",
-      "route": "reference-docs/operators/human"
-    },
-    {
-      "source": "documentation/configuration/workflowdef/systemtasks/wait-task.md",
-      "docId": "reference-docs/operators/wait",
-      "route": "reference-docs/operators/wait"
-    },
-    {
-      "source": "documentation/configuration/workflowdef/systemtasks/index.md",
-      "docId": "reference-docs/system-tasks/index",
-      "route": "category/reference-docs/system-tasks"
-    },
-    {
-      "source": "documentation/configuration/workflowdef/systemtasks/event-task.md",
-      "docId": "reference-docs/system-tasks/event",
-      "route": "reference-docs/system-tasks/event"
-    },
-    {
-      "source": "documentation/configuration/workflowdef/systemtasks/http-task.md",
-      "docId": "reference-docs/system-tasks/http",
-      "route": "reference-docs/system-tasks/http"
-    },
-    {
-      "source": "documentation/configuration/workflowdef/systemtasks/inline-task.md",
-      "docId": "reference-docs/system-tasks/inline",
-      "route": "reference-docs/system-tasks/inline"
-    },
-    {
-      "source": "documentation/configuration/workflowdef/systemtasks/json-jq-transform-task.md",
-      "docId": "reference-docs/system-tasks/jq-transform",
-      "route": "reference-docs/system-tasks/jq-transform"
-    },
-    {
-      "source": "documentation/configuration/workflowdef/systemtasks/jdbc-task.md",
-      "docId": "reference-docs/system-tasks/jdbc",
-      "route": "reference-docs/system-tasks/jdbc"
-    },
-    {
-      "source": "documentation/configuration/workflowdef/systemtasks/kafka-publish-task.md",
-      "docId": "reference-docs/system-tasks/kafka-publish",
-      "route": "reference-docs/system-tasks/kafka-publish"
-    },
-    {
-      "source": "documentation/configuration/workflowdef/systemtasks/noop-task.md",
-      "docId": "reference-docs/system-tasks/noop",
-      "route": "reference-docs/system-tasks/noop"
     }
   ],
   "aliases": {
@@ -344,6 +234,28 @@
     "documentation/configuration/workflowdef/index.md": "reference-docs/api/metadata/creating-workflow-definition",
     "documentation/configuration/workflowdef/operators/index.md": "category/reference-docs/operators",
     "devguide/how-tos/event-bus.md": "eventing",
-    "documentation/api/taskdomains.md": "developer-guides/task-to-domain"
+    "documentation/api/taskdomains.md": "developer-guides/task-to-domain",
+    "devguide/ai/index.md": "ai-orchestration",
+    "documentation/configuration/workflowdef/systemtasks/index.md": "category/reference-docs/system-tasks",
+    "documentation/configuration/workflowdef/operators/switch-task.md": "reference-docs/operators/switch",
+    "documentation/configuration/workflowdef/operators/do-while-task.md": "reference-docs/operators/do-while",
+    "documentation/configuration/workflowdef/operators/dynamic-task.md": "reference-docs/operators/dynamic",
+    "documentation/configuration/workflowdef/operators/dynamic-fork-task.md": "reference-docs/operators/dynamic-fork",
+    "documentation/configuration/workflowdef/operators/fork-task.md": "reference-docs/operators/fork-join",
+    "documentation/configuration/workflowdef/operators/join-task.md": "reference-docs/operators/join",
+    "documentation/configuration/workflowdef/operators/set-variable-task.md": "reference-docs/operators/set-variable",
+    "documentation/configuration/workflowdef/operators/start-workflow-task.md": "reference-docs/operators/start-workflow",
+    "documentation/configuration/workflowdef/operators/sub-workflow-task.md": "reference-docs/operators/sub-workflow",
+    "documentation/configuration/workflowdef/operators/terminate-task.md": "reference-docs/operators/terminate",
+    "documentation/configuration/workflowdef/systemtasks/human-task.md": "reference-docs/operators/human",
+    "documentation/configuration/workflowdef/systemtasks/wait-task.md": "reference-docs/operators/wait",
+    "documentation/configuration/workflowdef/systemtasks/event-task.md": "reference-docs/system-tasks/event",
+    "documentation/configuration/workflowdef/systemtasks/http-task.md": "reference-docs/system-tasks/http",
+    "documentation/configuration/workflowdef/systemtasks/inline-task.md": "reference-docs/system-tasks/inline",
+    "documentation/configuration/workflowdef/systemtasks/json-jq-transform-task.md": "reference-docs/system-tasks/jq-transform",
+    "documentation/configuration/workflowdef/systemtasks/jdbc-task.md": "reference-docs/system-tasks/jdbc",
+    "documentation/configuration/workflowdef/systemtasks/kafka-publish-task.md": "category/reference-docs/system-tasks",
+    "documentation/configuration/workflowdef/systemtasks/noop-task.md": "category/reference-docs/system-tasks",
+    "devguide/ai/mcp-guide.md": "developer-guides/mcp-gateway"
   }
 }

--- a/sidebars.js
+++ b/sidebars.js
@@ -209,7 +209,6 @@ const sidebars = {
                     },
                     items: [
                         { type: 'doc', id: 'reference-docs/system-tasks/event', label: 'Event Task' },
-                        { type: 'doc', id: 'reference-docs/system-tasks/kafka-publish', label: 'Kafka Publish Task' },
                         { type: 'doc', id: 'cookbook/event-driven', label: 'Event Publishing Recipes' },
                     ],
                 },
@@ -364,7 +363,6 @@ const sidebars = {
             items: [
                 { type: 'doc', id: 'ai-cookbook/ai-llm-recipes', label: 'AI & LLM Recipes' },
                 { type: 'doc', id: 'ai-cookbook/llm-orchestration', label: 'LLM Orchestration' },
-                { type: 'doc', id: 'ai-cookbook/mcp-integration', label: 'MCP Integration' },
             ],
         },
         {
@@ -447,7 +445,6 @@ const sidebars = {
                         'reference-docs/system-tasks/http-poll',
                         'reference-docs/system-tasks/inline',
                         'reference-docs/system-tasks/jq-transform',
-                        'reference-docs/system-tasks/noop',
                         'reference-docs/system-tasks/business-rule',
                         'reference-docs/system-tasks/sendgrid',
                         'reference-docs/system-tasks/jdbc',


### PR DESCRIPTION
## Summary
- **17 operator/system-task pages** (Switch, Do While, Dynamic, Dynamic Fork, Fork/Join, Join, Set Variable, Start Workflow, Sub Workflow, Terminate, Human, Wait, Event, HTTP, Inline, JQ Transform, JDBC) were being silently overwritten by generic OSS content at build time, even though Orkes already has richer, enterprise-specific versions (e.g. Wait's `yield` param, Do While's `captureOutput`). Removed from `shared-docs-map.json` so Orkes' own pages are served, with aliases added so other OSS pages that still link to them by relative path keep resolving.
- **Kafka Publish, No Op, and MCP tool-calling (`LIST_MCP_TOOLS`/`CALL_MCP_TOOL`)** are not available in Orkes Enterprise. Removed their 3 dedicated pages and sidebar entries entirely, with fallback aliases redirecting any remaining internal OSS links to the closest still-relevant page (system tasks index, MCP Gateway).
- **`ai-orchestration` (index)** and **`category/reference-docs/system-tasks`** adopted as Orkes-owned content (previously OSS-sourced) since both needed the Kafka/NOOP/MCP mentions stripped from their own body content, which isn't possible while still auto-syncing from OSS.
- Fixed one hardcoded link in `docs/agentic-workflow-engine.mdx` pointing at the now-removed MCP Integration page.

## Test plan
- [x] Ran `npm run build && npm run audit:docs` locally with the same env vars as CI — 507 pages, 0 errors
- [x] Confirmed no remaining mentions of Kafka Publish/No Op/`LIST_MCP_TOOLS`/`CALL_MCP_TOOL` in the body content of the adopted pages
- [ ] Reviewer spot-check of the rewritten `ai-orchestration` page content and tone

## Known follow-up (not in this PR)
- `ai-orchestration/first-ai-agent` and `ai-orchestration/production-agent-architecture` still use `LIST_MCP_TOOLS`/`CALL_MCP_TOOL` as their core worked example — needs a decision on rewriting with `HTTP` task or removing those pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)