### PR TITLE
Nav lockstep for AI Cookbook and Platform, redirects for dropped URLs, tab bar fit

### DIFF
--- a/docs-redirects.json
+++ b/docs-redirects.json
@@ -107,5 +107,15 @@
   "quickstarts/workflows": "quickstart/workflows",
   "reference-docs/api/schedule/bulk-pause-schedule": "reference-docs/api/schedule",
   "reference-docs/api/schedule/bulk-resume-schedule": "reference-docs/api/schedule",
-  "reference-docs/api/schedule/get-next-few-schedules": "reference-docs/api/schedule"
+  "reference-docs/api/schedule/get-next-few-schedules": "reference-docs/api/schedule",
+  "developer-guides/gateway-metrics": "developer-guides/mcp-api-gateway",
+  "category/integrations/connections-and-resources": "category/integrations",
+  "developer-guides/advanced-workflows": "developer-guides/building-workflows",
+  "developer-guides/monitoring-task-queues": "developer-guides/metrics-and-observability",
+  "inputs-outputs": "developer-guides/passing-inputs-to-task-in-conductor",
+  "reference-docs/api/synchronous-workflow-execution": "reference-docs/api/workflow",
+  "reference-docs/api/workflow/pause-worflow": "reference-docs/api/workflow",
+  "sdks/clojure": "sdks/sdk-index",
+  "templates/agentic-research": "category/tutorials",
+  "templates/claims-workflow": "category/tutorials"
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,33 +21,13 @@ nav:
     - Bring Your Framework Agent: quickstart/framework-agents.md
     - Run a Workflow from JSON: quickstarts.md
     - Conductor for AI Assistants: devguide/ai/conductor-for-ai-assistants.md
-    - Install and Set Up Orkes Conductor: get-orkes-conductor.md
-  - Platform:
-    - Core Concepts: devguide/concepts.md
-    - Why Conductor: core-concepts.md
-    - Architecture: devguide/architecture.md
+    - Concepts: core-concepts.md
     - Durable Execution: quickstart/durable-execution.md
     - JSON + Code Native: quickstart/json-code-native.md
     - Task Lifecycle: quickstart/task-lifecycle.md
-    - Deploy:
-      - Production Deployment: devguide/running/deploy.md
-      - From Source: devguide/running/source.md
-      - Hosted: devguide/running/hosted.md
-      - CI/CD Integration: developer-guides/integration-with-cicd.md
-      - Best Practices: devguide/bestpractices.md
-    - Configuration: documentation/configuration/appconf.md
-    - Observability:
-      - Server Metrics: developer-guides/metrics-and-observability.md
-      - Client Metrics: documentation/metrics/client.md
-    - Advanced:
-      - Extending Conductor: documentation/advanced/extend.md
-      - Isolation Groups: documentation/advanced/isolationgroups.md
-      - Archiving Workflows: documentation/advanced/archival-of-workflows.md
-      - External Payload Storage: documentation/advanced/externalpayloadstorage.md
-      - File Storage: documentation/advanced/file-storage.md
-      - Redis: documentation/advanced/redis.md
-      - PostgreSQL: documentation/advanced/postgresql.md
-      - OpenSearch: documentation/advanced/opensearch.md
+    - Install and Set Up Orkes Conductor: get-orkes-conductor.md
+    - Core Concepts: devguide/concepts.md
+    - Conductor Architecture: devguide/architecture.md
   - Workflows:
     - Overview: devguide/workflows.md
     - Workflows: quickstart/workflows.md
@@ -109,20 +89,9 @@ nav:
       - Using Vector Databases: reference-docs/ai-tasks.md
       - Creating AI Prompts: developer-guides/creating-and-managing-gen-ai-prompt-templates.md
     - Agentic Workflow Engine: agentic-workflow-engine.md
-  - Design Patterns:
-    - Overview: devguide/cookbook.md
-    - Workflow Patterns:
-      - Microservice Orchestration: cookbook/microservice-orchestration.md
-      - Dynamic Parallelism: cookbook/dynamic-parallelism.md
-      - "Wait & Timer Patterns": cookbook/wait-and-timers.md
-      - "Task Timeouts & Retries": cookbook/task-timeouts-and-retries.md
-      - "Saga & Compensation": devguide/cookbook/saga-compensation.md
-      - "Polling a Long-Running Job": devguide/cookbook/http-poll-long-running-job.md
-      - Scheduled Workflows: cookbook/workflow-scheduling.md
-      - Dynamic Workflows in Code: cookbook/dynamic-workflows.md
-      - "Event-Driven Patterns": cookbook/event-driven.md
+  - AI Cookbook:
+    - Overview: devguide/ai/cookbook.md
     - Agentic Patterns:
-      - Overview: devguide/ai/cookbook.md
       - RAG Agent: devguide/ai/cookbook/rag-agent.md
       - MCP Tool Calling: devguide/ai/cookbook/mcp-tool-calling.md
       - A2A Agent Orchestration: devguide/ai/cookbook/a2a-orchestration.md
@@ -145,6 +114,18 @@ nav:
       - Specialist Review: devguide/ai/cookbook/parallel-specialist-review.md
       - Agent Approval: devguide/ai/cookbook/human-approved-action.md
       - Agent Cancellation: devguide/ai/cookbook/conductor-agent-cancellation.md
+  - Design Patterns:
+    - Overview: devguide/cookbook.md
+    - Workflow Patterns:
+      - Microservice Orchestration: cookbook/microservice-orchestration.md
+      - Dynamic Parallelism: cookbook/dynamic-parallelism.md
+      - "Wait & Timer Patterns": cookbook/wait-and-timers.md
+      - "Task Timeouts & Retries": cookbook/task-timeouts-and-retries.md
+      - "Saga & Compensation": devguide/cookbook/saga-compensation.md
+      - "Polling a Long-Running Job": devguide/cookbook/http-poll-long-running-job.md
+      - Scheduled Workflows: cookbook/workflow-scheduling.md
+      - Dynamic Workflows in Code: cookbook/dynamic-workflows.md
+      - "Event-Driven Patterns": cookbook/event-driven.md
     - Cookbook: category/tutorials.md
     - Document Approval: _routes/templates/examples/document-approvals.md
     - "Long-Running APIs": tutorials/long-running-apis.md
@@ -596,6 +577,26 @@ nav:
         - Delete Tags from Prompt: reference-docs/api/prompts/delete-tags-from-prompt.md
         - Test Prompts: reference-docs/api/prompts/test-prompts.md
     - Glossary: glossary.md
+  - Platform:
+    - Deploy:
+      - Production Deployment: devguide/running/deploy.md
+      - From Source: devguide/running/source.md
+      - Hosted: devguide/running/hosted.md
+      - CI/CD Integration: developer-guides/integration-with-cicd.md
+      - Best Practices: devguide/bestpractices.md
+    - Configuration: documentation/configuration/appconf.md
+    - Observability:
+      - Server Metrics: developer-guides/metrics-and-observability.md
+      - Client Metrics: documentation/metrics/client.md
+    - Advanced:
+      - Extending Conductor: documentation/advanced/extend.md
+      - Isolation Groups: documentation/advanced/isolationgroups.md
+      - Archiving Workflows: documentation/advanced/archival-of-workflows.md
+      - External Payload Storage: documentation/advanced/externalpayloadstorage.md
+      - File Storage: documentation/advanced/file-storage.md
+      - Redis: documentation/advanced/redis.md
+      - PostgreSQL: documentation/advanced/postgresql.md
+      - OpenSearch: documentation/advanced/opensearch.md
 
 not_in_nav: |
   search.md
@@ -760,6 +761,16 @@ plugins:
         reference-docs/api/schedule/bulk-pause-schedule.md: reference-docs/api/schedule.md
         reference-docs/api/schedule/bulk-resume-schedule.md: reference-docs/api/schedule.md
         reference-docs/api/schedule/get-next-few-schedules.md: reference-docs/api/schedule.md
+        developer-guides/gateway-metrics.md: developer-guides/mcp-api-gateway.md
+        category/integrations/connections-and-resources.md: category/integrations.md
+        developer-guides/advanced-workflows.md: developer-guides/building-workflows.md
+        developer-guides/monitoring-task-queues.md: developer-guides/metrics-and-observability.md
+        inputs-outputs.md: developer-guides/passing-inputs-to-task-in-conductor.md
+        reference-docs/api/synchronous-workflow-execution.md: reference-docs/api/workflow.md
+        reference-docs/api/workflow/pause-worflow.md: reference-docs/api/workflow.md
+        sdks/clojure.md: sdks/sdk-index.md
+        templates/agentic-research.md: category/tutorials.md
+        templates/claims-workflow.md: category/tutorials.md
   - macros
 
 markdown_extensions:

--- a/scripts/generate-mkdocs-site.js
+++ b/scripts/generate-mkdocs-site.js
@@ -2556,36 +2556,6 @@ function ossNavTabs() {
     d("quickstart/first-workflow", "Run a Workflow from JSON"),
     d("devguide/ai/conductor-for-ai-assistants", "Conductor for AI Assistants"),
   ]],
-  ["Platform", [
-    d("devguide/concepts", "Core Concepts"),
-    d("devguide/concepts/conductor", "Why Conductor"),
-    d("devguide/architecture", "Architecture"),
-    d("architecture/durable-execution", "Durable Execution"),
-    d("architecture/json-native", "JSON + Code Native"),
-    d("devguide/architecture/tasklifecycle", "Task Lifecycle"),
-    cat("Deploy", [
-      d("devguide/running/deploy", "Production Deployment"),
-      d("devguide/running/source", "From Source"),
-      d("devguide/running/hosted", "Hosted"),
-      d("devguide/how-tos/cicd-integration", "CI/CD Integration"),
-      d("devguide/bestpractices", "Best Practices"),
-    ]),
-    d("documentation/configuration/appconf", "Configuration"),
-    cat("Observability", [
-      d("documentation/metrics/server", "Server Metrics"),
-      d("documentation/metrics/client", "Client Metrics"),
-    ]),
-    cat("Advanced", [
-      d("documentation/advanced/extend"),
-      d("documentation/advanced/isolationgroups"),
-      d("documentation/advanced/archival-of-workflows"),
-      d("documentation/advanced/externalpayloadstorage"),
-      d("documentation/advanced/file-storage"),
-      d("documentation/advanced/redis"),
-      d("documentation/advanced/postgresql"),
-      d("documentation/advanced/opensearch"),
-    ]),
-  ]],
   ["Workflows", [
     d("devguide/workflows", "Overview"),
     d("devguide/concepts/workflows", "Workflows"),
@@ -2640,21 +2610,9 @@ function ossNavTabs() {
     ]),
     d("devguide/ai/production-agent-architecture", "Production Agent Architecture"),
   ]],
-  ["Design Patterns", [
-    d("devguide/cookbook", "Overview"),
-    cat("Workflow Patterns", [
-      d("devguide/cookbook/microservice-orchestration", "Microservice Orchestration"),
-      d("devguide/cookbook/dynamic-parallelism", "Dynamic Parallelism"),
-      d("devguide/cookbook/wait-and-timers", "Wait & Timer Patterns"),
-      d("devguide/cookbook/task-timeouts-and-retries", "Task Timeouts & Retries"),
-      d("devguide/cookbook/saga-compensation", "Saga & Compensation"),
-      d("devguide/cookbook/http-poll-long-running-job", "Polling a Long-Running Job"),
-      d("devguide/cookbook/workflow-scheduling", "Scheduled Workflows"),
-      d("devguide/cookbook/dynamic-workflows", "Dynamic Workflows in Code"),
-      d("devguide/cookbook/event-driven", "Event-Driven Patterns"),
-    ]),
+  ["AI Cookbook", [
+    d("devguide/ai/cookbook", "Overview"),
     cat("Agentic Patterns", [
-      d("devguide/ai/cookbook", "Overview"),
       d("devguide/ai/cookbook/rag-agent", "RAG Agent"),
       d("devguide/ai/cookbook/mcp-tool-calling", "MCP Tool Calling"),
       d("devguide/ai/cookbook/a2a-orchestration", "A2A Agent Orchestration"),
@@ -2680,6 +2638,20 @@ function ossNavTabs() {
       d("devguide/ai/cookbook/conductor-agent-cancellation", "Agent Cancellation"),
     ]),
   ]],
+  ["Design Patterns", [
+    d("devguide/cookbook", "Overview"),
+    cat("Workflow Patterns", [
+      d("devguide/cookbook/microservice-orchestration", "Microservice Orchestration"),
+      d("devguide/cookbook/dynamic-parallelism", "Dynamic Parallelism"),
+      d("devguide/cookbook/wait-and-timers", "Wait & Timer Patterns"),
+      d("devguide/cookbook/task-timeouts-and-retries", "Task Timeouts & Retries"),
+      d("devguide/cookbook/saga-compensation", "Saga & Compensation"),
+      d("devguide/cookbook/http-poll-long-running-job", "Polling a Long-Running Job"),
+      d("devguide/cookbook/workflow-scheduling", "Scheduled Workflows"),
+      d("devguide/cookbook/dynamic-workflows", "Dynamic Workflows in Code"),
+      d("devguide/cookbook/event-driven", "Event-Driven Patterns"),
+    ]),
+  ]],
   ["SDK", [
     d("documentation/clientsdks", "Overview"),
     d("documentation/clientsdks/java-sdk", "Java"),
@@ -2690,6 +2662,39 @@ function ossNavTabs() {
     d("documentation/clientsdks/ruby-sdk", "Ruby"),
     d("documentation/clientsdks/rust-sdk", "Rust"),
   ]],
+  ];
+}
+
+function platformTabItems() {
+  return [
+    d("devguide/concepts", "Core Concepts"),
+    d("devguide/concepts/conductor", "Why Conductor"),
+    d("devguide/architecture", "Architecture"),
+    d("architecture/durable-execution", "Durable Execution"),
+    d("architecture/json-native", "JSON + Code Native"),
+    d("devguide/architecture/tasklifecycle", "Task Lifecycle"),
+    cat("Deploy", [
+      d("devguide/running/deploy", "Production Deployment"),
+      d("devguide/running/source", "From Source"),
+      d("devguide/running/hosted", "Hosted"),
+      d("devguide/how-tos/cicd-integration", "CI/CD Integration"),
+      d("devguide/bestpractices", "Best Practices"),
+    ]),
+    d("documentation/configuration/appconf", "Configuration"),
+    cat("Observability", [
+      d("documentation/metrics/server", "Server Metrics"),
+      d("documentation/metrics/client", "Client Metrics"),
+    ]),
+    cat("Advanced", [
+      d("documentation/advanced/extend"),
+      d("documentation/advanced/isolationgroups"),
+      d("documentation/advanced/archival-of-workflows"),
+      d("documentation/advanced/externalpayloadstorage"),
+      d("documentation/advanced/file-storage"),
+      d("documentation/advanced/redis"),
+      d("documentation/advanced/postgresql"),
+      d("documentation/advanced/opensearch"),
+    ]),
   ];
 }
 
@@ -2745,16 +2750,12 @@ function buildNav() {
   }
 
   tabChildren["Getting Started"].push(...navFromItems(sidebars.quickstartSidebar, navSeen));
-  tabChildren.Platform.push(
-    ...navFromItems([...guideExtras.Platform, ...sidebars.deploySidebar], navSeen),
-  );
   tabChildren.Workflows.push(...navFromItems(guideExtras.Workflows, navSeen));
   tabChildren.Agents.push(
     ...navFromItems([...guideExtras.Agents, ...sidebars.aiSidebar], navSeen),
   );
-  tabChildren["Design Patterns"].push(
-    ...navFromItems([...sidebars.cookbookSidebar, ...sidebars.aiCookbookSidebar], navSeen),
-  );
+  tabChildren["Design Patterns"].push(...navFromItems(sidebars.cookbookSidebar, navSeen));
+  tabChildren["AI Cookbook"].push(...navFromItems(sidebars.aiCookbookSidebar, navSeen));
   tabChildren.SDK.push(...navFromItems(sidebars.sdksSidebar, navSeen));
 
   integrationsChildren.push(
@@ -2784,6 +2785,11 @@ function buildNav() {
     ),
   });
   nav.push({ Reference: navFromItems(sidebars.referenceSidebar, navSeen) });
+  const platformChildren = navFromItems(platformTabItems(), navSeen);
+  platformChildren.push(
+    ...navFromItems([...guideExtras.Platform, ...sidebars.deploySidebar], navSeen),
+  );
+  nav.push({ Platform: platformChildren });
 
   // Keep legacy indexed category URLs even when their groups are intentionally
   // removed from the visible navigation.

--- a/scripts/generate-mkdocs-site.js
+++ b/scripts/generate-mkdocs-site.js
@@ -3580,6 +3580,9 @@ body[data-md-color-scheme="default"] .md-header--shadow ~ .md-tabs {
 .md-header .md-social__link {
   color: var(--c-header-text) !important;
 }
+.md-tabs__item {
+  padding: 0 0.15rem;
+}
 .md-tabs__link {
   color: var(--c-header-muted) !important;
   border: 1px solid transparent;
@@ -3587,7 +3590,8 @@ body[data-md-color-scheme="default"] .md-header--shadow ~ .md-tabs {
   display: inline-flex;
   align-items: center;
   min-height: 1.8rem;
-  padding: 0.25rem 0.62rem;
+  font-size: 0.66rem;
+  padding: 0.25rem 0.5rem;
   transition: color 140ms ease, background 140ms ease, border-color 140ms ease, box-shadow 140ms ease;
 }
 .md-tabs__item--active > .md-tabs__link,


### PR DESCRIPTION
Follow-ups to the merged nav/home parity PR (#1116):

- Mirrors the OSS nav changes from conductor-oss/conductor#1525
    - AI Cookbook becomes a top-level tab after Agents
    - Platform moves to the end of the tab bar.
- Adds redirects for 10 live orkes.io/content URLs the merge had dropped without coverage
- Tightens the top tab bar so all twelve tabs fit on one row without horizontal scrolling.