### PR TITLE
Add prod S3 deploy workflow

### DIFF
--- a/.github/workflows/deploy-docs-prod-s3.yml
+++ b/.github/workflows/deploy-docs-prod-s3.yml
@@ -1,0 +1,93 @@
+name: Deploy Docs to S3 — prod
+
+# Builds the MkDocs site with base=/content and publishes it to the S3 bucket in
+# the marketing-prod account, then invalidates the /content/* path on the prod
+# marketing CloudFront distribution. Mirrors deploy-docs-s3.yml (non-prod).
+#
+# This bucket is NOT public yet — orkes.io/content is still served by the
+# portal-baked Docusaurus build. Until the distribution is repointed, deploying
+# here is safe and replaces deploying by hand from a laptop.
+#
+# !! AT CUTOVER: change the push trigger to `branches: [main]` BEFORE repointing
+# CloudFront. Left as-is, every merge into the integration branch would publish
+# straight to the live site. Config lives in the `marketing-prod` GitHub
+# Environment (see deploy/SETUP-s3-cloudfront.md).
+
+on:
+  push:
+    branches: [refactor/docs-oss-enterprise-merge] # → [main] at cutover
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write # OIDC → AWS
+
+concurrency:
+  group: docs-s3-prod
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Build (base=/content) → S3 + invalidate
+    runs-on: ubuntu-latest
+    environment: marketing-prod
+    env:
+      DOCS_BASE_URL: /content
+      DOCS_SITE_URL: ${{ vars.DOCS_SITE_URL }} # https://orkes.io/content/ ; unset falls back to the same
+      # Google Tag Manager is off in every other build (dev, non-prod, Pages
+      # preview) so their traffic stays out of the production GA4 property.
+      # This is the one job that turns it on — drop it and prod ships unmeasured.
+      DOCS_ENABLE_ANALYTICS: "1"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Fetch shared OSS docs
+        run: npm run fetch:oss-docs
+
+      - name: Build site (base=/content)
+        run: npm run build
+
+      - name: Audit generated site
+        run: npm run audit:docs
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      # Hashed, content-addressed Material assets → cache 1 year, immutable.
+      - name: Sync immutable assets
+        run: |
+          aws s3 sync build/ "s3://${{ vars.DOCS_BUCKET }}/content/" \
+            --delete \
+            --cache-control "public, max-age=31536000, immutable" \
+            --exclude "*" --include "assets/*"
+
+      # Everything else (HTML, images, search index) → short cache; prune stale.
+      - name: Sync HTML + the rest
+        run: |
+          aws s3 sync build/ "s3://${{ vars.DOCS_BUCKET }}/content/" \
+            --delete \
+            --cache-control "public, max-age=300" \
+            --exclude "assets/*"
+
+      - name: Invalidate CloudFront /content/*
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id "${{ vars.MARKETING_CF_DIST_ID }}" \
+            --paths "/content/*"

--- a/deploy/SETUP-s3-cloudfront.md
+++ b/deploy/SETUP-s3-cloudfront.md
@@ -86,17 +86,30 @@ container instead of pointing non-prod at the real one.
 ## Later: promoting to prod (not now)
 Mirror this in the **marketing-prod** account — its own bucket
 (`orkes-docs-prod`), the `/content/*` behavior + function on the **prod**
-distribution, and a `marketing-prod` GitHub Environment. Then either add a
-`prod` job/trigger to this workflow or a separate one. Only at that point do you
-repoint `orkes.io` `/content` off the portal-baked Docusaurus.
+distribution, and a `marketing-prod` GitHub Environment. Only at that point do
+you repoint `orkes.io` `/content` off the portal-baked Docusaurus.
 
-**Set `DOCS_ENABLE_ANALYTICS: 1` on that prod job.** Nothing sets it today, so
-every current build ships with no analytics at all — miss this at cutover and
-`orkes.io/content` goes live unmeasured. It injects Google Tag Manager
-(`GTM-M4Q6Z3R2`, overridable via `DOCS_GTM_ID`) into `<head>`. The container owns
-GA4 and Google Ads; the site deliberately does not load `gtag.js` itself, since
-the Docusaurus build configured `G-4400JPTLRF` both on-page and inside the
-container and double-counted `page_view`.
+The workflow already exists: **`.github/workflows/deploy-docs-prod-s3.yml`**.
+Same build and audit steps as non-prod, `environment: marketing-prod`, and for
+now it pushes on `refactor/docs-oss-enterprise-merge` — the prod bucket is not
+public yet, so this just replaces deploying to it by hand.
+
+> **Before repointing CloudFront, change that trigger to `branches: [main]`.**
+> Otherwise every merge into the integration branch publishes to the live site.
+
+Populate the `marketing-prod` Environment with the same five
+variables as the table above, with `DOCS_SITE_URL` set to
+`https://orkes.io/content/` — if you leave it unset the build falls back to that
+same value, so it is safe either way.
+
+That workflow is also the only build that sets **`DOCS_ENABLE_ANALYTICS: "1"`**,
+which injects Google Tag Manager (`GTM-M4Q6Z3R2`, overridable via `DOCS_GTM_ID`)
+into `<head>`. Every other build — dev, non-prod, Pages preview — ships without
+analytics by design. If you replace or rewrite this job, keep that variable or
+prod goes live unmeasured. The container owns GA4 and Google Ads; the site
+deliberately does not load `gtag.js` itself, since the Docusaurus build
+configured `G-4400JPTLRF` both on-page and inside the container and
+double-counted `page_view`.
 
 One duplicate survives on the container side and can only be fixed in the GTM
 console: a GA4 event tag named `page_view` on an All Pages trigger, on top of the

--- a/scripts/generate-mkdocs-site.js
+++ b/scripts/generate-mkdocs-site.js
@@ -27,10 +27,10 @@ const DEVELOPER_EDITION_URL =
 const GTM_CONTAINER_ID = process.env.DOCS_GTM_ID || "GTM-M4Q6Z3R2";
 // Off unless a deploy opts in, so local dev servers, the non-prod S3 build, and
 // the GitHub Pages preview never send page_view into the production property.
-// NOTE: nothing sets DOCS_ENABLE_ANALYTICS today, so every current build ships
-// without analytics. Production orkes.io/content is still the Docusaurus build,
-// deployed outside this repo; the MkDocs production deploy must set it to 1 at
-// cutover or the site goes live unmeasured. See deploy/SETUP-s3-cloudfront.md.
+// Only .github/workflows/deploy-docs-prod-s3.yml sets it. That workflow is
+// manual-dispatch only and does not serve orkes.io/content yet (production is
+// still the Docusaurus build, deployed outside this repo), so in practice every
+// build today ships unmeasured. See deploy/SETUP-s3-cloudfront.md.
 const ANALYTICS_ENABLED = /^(1|true|yes)$/i.test(process.env.DOCS_ENABLE_ANALYTICS || "");
 const AGENTSPAN_RELATIONSHIP_COPY =
   "Agentspan is the developer-facing agent runtime. Conductor OSS is the durable workflow engine underneath. Orkes Conductor is the managed enterprise platform for operating Conductor-based systems at scale.";


### PR DESCRIPTION
## Summary
Mirrors `deploy-docs-s3.yml` against the marketing-prod environment, so the prod bucket gets the same audited CI build instead of hand-rolled local deploys. Pushes on `refactor/docs-oss-enterprise-merge` for now — that bucket
is not public yet.

Sets `DOCS_ENABLE_ANALYTICS=1`, the only build that enables GTM.

Switch the trigger to `[main]` before repointing CloudFront, or every merge into the integration branch publishes to the live site.