### PR TITLE
Enablement notes for task search, Connected Apps, audit logs; audit API

### DIFF
--- a/docs/access-control-and-security/audit-logs.mdx
+++ b/docs/access-control-and-security/audit-logs.mdx
@@ -15,6 +15,10 @@ Audit logs capture changes, such as updating a workflow definition or rotating a
 
 Viewing audit logs requires administrator access. Users and applications without administrator permissions cannot view audit log data, even if they have access to the underlying resources.
 
+## Enabling audit logs
+
+Audit logging is disabled by default. To enable it for your cluster, contact Orkes support. Once it is enabled, hard-refresh the Conductor UI to see **Executions > Audit Logs** in the left navigation.
+
 ## When to use audit logs
 
 Use audit logs when you need to answer "who changed this, and what did it look like before." Common cases include investigating an unexpected workflow behavior after a definition change, reviewing access control changes for a security audit, and confirming when a secret or environment variable was last rotated.
@@ -86,6 +90,23 @@ To view audit logs from Conductor UI:
 ## Viewing change history for a resource
 
 To see every recorded change for a single resource, select its Resource Type and Resource ID from a search result to open its change history. This view lists every audited change to that resource in chronological order, so you can trace how its configuration evolved over time.
+
+## Audit log API
+
+The same data is available through the audit API. Like the UI, it requires administrator access. Search endpoints return a `SearchResult` with `totalHits` and `results`, where each result has the fields described in [What's captured for each entry](#whats-captured-for-each-entry).
+
+| Endpoint | Description |
+| --- | --- |
+| `GET /api/audit/search` | Search audit logs. Optional query parameters: `entityType`, `entityId`, `userId`, `action` (`WRITE` or `DELETE`), `startTime` and `endTime` (epoch milliseconds), `start` (offset, default `0`), `size` (default `100`). |
+| `GET /api/audit/{entityType}/{entityId}` | Change history for one resource. Optional query parameters: `startTime`, `endTime`, `start`, `size`. |
+| `GET /api/audit/entity-types` | The resource types that are audited. |
+
+For example, to list every change to the `order_status_lookup` workflow definition:
+
+```shell
+curl -X GET '<YOUR-CLUSTER-URL>/api/audit/WORKFLOW_DEF/order_status_lookup' \
+  -H 'X-Authorization: <TOKEN>'
+```
 
 ## Best practices
 

--- a/scripts/generate-mkdocs-site.js
+++ b/scripts/generate-mkdocs-site.js
@@ -1510,6 +1510,21 @@ function insertAfterIntro(body, addition) {
   return body.replace(match[0], `${match[0]}${cleanAddition}\n\n`);
 }
 
+const CONNECTED_APPS_NOTE = [
+  '!!! note "Connected Apps must be enabled on your cluster"',
+  "",
+  "    Connected Apps are enabled per cluster. If **Integrations > Connected Apps** is not in",
+  "    the left navigation, contact Orkes support to enable it before following these steps.",
+].join("\n");
+
+// Every connected-app guide page (not the *-operations references) gets the
+// enablement note right after its "Available since" admonition.
+function injectConnectedAppsNote(body, sourceRel) {
+  if (!sourceRel.startsWith("integrations/connected-apps/")) return body;
+  if (/-operations\.mdx?$/.test(sourceRel)) return body;
+  return insertAfterIntro(body, CONNECTED_APPS_NOTE);
+}
+
 function insertBeforeHeading(body, heading, addition) {
   const cleanAddition = addition.trim();
   if (!cleanAddition) return body;
@@ -1533,6 +1548,39 @@ function enhancePositioningPage(body, route) {
     output = insertAfterIntro(
       output,
       platformVariant === "concept" ? PLATFORM_CONCEPT_CALLOUT : PLATFORM_OPS_CALLOUT,
+    );
+  }
+
+  if (route === "devguide/how-tos/Workflows/searching-workflows") {
+    output = insertBeforeHeading(
+      output,
+      "Limitations and next step",
+      [
+        "## Orkes Conductor: searching task executions",
+        "",
+        "On Orkes Conductor, **Executions > Workflow** is the search described above. Clusters",
+        "with task indexing enabled also have **Executions > Task**, which searches task",
+        "executions directly with these filters:",
+        "",
+        "| Filter | Description |",
+        "|---|---|",
+        "| Task definition name | One or more task definition names. |",
+        "| Task type | One or more task types, such as `SIMPLE` or `HTTP`. |",
+        "| Task execution id | A specific task execution ID. |",
+        "| Task reference name | The task's reference name in the workflow definition. |",
+        "| Workflow name | Only tasks that belong to these workflow definitions. |",
+        "| Status | One or more task statuses. |",
+        "| Free text search | Full-text query over indexed task data. |",
+        "",
+        "Turn on **SQL format** to write the query directly, for example",
+        "`taskType = 'HTTP' AND status = 'FAILED'`.",
+        "",
+        '!!! note "Task indexing is enabled per cluster"',
+        "",
+        "    Task indexing is off by default. If **Executions > Task** is not in the left",
+        "    navigation, it is not enabled on your cluster. Contact Orkes support to turn it",
+        "    on, then hard-refresh the UI.",
+      ].join("\n"),
     );
   }
 
@@ -1896,7 +1944,10 @@ function convertEntry(entry) {
   const title = extractTitle(body, frontMatter, route);
   const pageTitle = pageTitleForRoute(route, title);
   const sourceBody = entry.shared ? transformSharedBody(body, entry) : body;
-  const cleaned = enhancePositioningPage(cleanMdx(sourceBody, sourceRel), route);
+  const cleaned = injectConnectedAppsNote(
+    enhancePositioningPage(cleanMdx(sourceBody, sourceRel), route),
+    sourceRel,
+  );
   const related = relatedPagesBlock(route, cleaned);
   return `${buildFrontMatter(frontMatter, route, pageTitle)}${cleaned}${related}`;
 }
@@ -1943,6 +1994,19 @@ description: "Orkes Conductor documentation for building durable workflows, API 
 ${body}`;
 }
 
+// Connected Apps category pages (the hub and its per-type subcategories) carry
+// the same per-cluster enablement note as the guide pages.
+function isConnectedAppsCategory(route, flatChildren) {
+  if (route === "category/integrations/connected-apps") return true;
+  return flatChildren.some((child) => {
+    const childRoute =
+      child.route || (child.outRel ? routeFromOutRel(child.outRel) : "") || "";
+    return (sourceRelByRoute.get(childRoute) || "").startsWith(
+      "integrations/connected-apps/",
+    );
+  });
+}
+
 function generatedPageCopy(route, title, description, flatChildren) {
   if (route === "category/tutorials") {
     return cookbookPageCopy();
@@ -1970,6 +2034,12 @@ function generatedPageCopy(route, title, description, flatChildren) {
   if (description) lines.push(description, "");
   lines.push(intro, "");
   lines.push(outcome, "");
+  if (isConnectedAppsCategory(route, flatChildren)) {
+    lines.push(
+      "Connected Apps were introduced in v5.3.0 and are enabled per cluster; each app's page lists its own minimum version. If **Integrations > Connected Apps** is not in your cluster's left navigation, contact Orkes support to enable it.",
+      "",
+    );
+  }
   lines.push(...apiIndexQuickReferenceLines(route, flatChildren));
 
   if (childLabels.length) {


### PR DESCRIPTION
Slack context:
https://orkesinternal.slack.com/archives/C047885J9TP/p1788288401172459

## 1. Executions > Task

The Searching Workflows page comes from the OSS docs and never mentions the Orkes task search page.

The build now adds an Enterprise section to that page. It covers the filters on **Executions > Task**, the SQL format toggle, and a note that the page only shows up once task indexing is enabled for the cluster.

## 2. Connected Apps

Connected Apps only appear in the UI once they are enabled for a cluster. None of the guide pages said so.

The build now adds a short "must be enabled on your cluster" note to every connected-app guide page (23 pages) and to the Connected Apps category pages. The `*-operations` reference pages are left alone.

## 3. Audit logs

Two new sections on the audit logs page:

- **Enabling audit logs**: off by default, contact support, then hard-refresh the UI.
- **Audit log API**: the three `/api/audit` endpoints and their query parameters.

## Related

- Companion OSS PR: https://github.com/conductor-oss/conductor/pull/1596
