### PR TITLE
v5.5.2

### DIFF
--- a/docs/reference-docs/api/applications/delete-application.mdx
+++ b/docs/reference-docs/api/applications/delete-application.mdx
@@ -20,6 +20,7 @@ Deletes an application from your Conductor cluster.
 
 - Returns a message indicating that the application has been deleted. 
 - Returns 404 if an invalid application ID is provided.
+- Returns 500 if the application could not be deleted.
 
 ## Examples
 

--- a/docs/reference-docs/api/secrets/list-accessible-secrets.mdx
+++ b/docs/reference-docs/api/secrets/list-accessible-secrets.mdx
@@ -16,7 +16,7 @@ Retrieves all secret names that the user has access to. Use the `access` query p
 
 | Parameter | Description                                    | Type   | Required/ Optional |
 | --------- | ---------------------------------------------- | ------ | ------------------ |
-| access<br/><br/><TableNote title="Available since">v5.4.2 and later</TableNote> | Filter secrets by access type. Supported values:<ul><li>`READ`</li><li>`CREATE`</li><li>`UPDATE`</li><li>`DELETE`</li><li>`EXECUTE`</li></ul> Defaults to `READ` if not specified. Multiple values use AND semantics. Only secrets where the user has all specified access types are returned. | array of strings | Optional. |
+| access<br/><br/><TableNote title="Available since">v5.4.2 and later</TableNote> | Filter secrets by access type. Supported values:<ul><li>`READ`</li><li>`CREATE`</li><li>`UPDATE`</li><li>`DELETE`</li><li>`EXECUTE`</li></ul> Defaults to `READ` if not specified. Multiple values use AND semantics. Only secrets where the user has all specified access types are returned. A `READ` request is also satisfied by `UPDATE`, `DELETE`, or `EXECUTE` access, so a secret you can update, delete, or execute against still appears in the default listing even without explicit `READ`. | array of strings | Optional. |
 
 ## Response
 
@@ -40,7 +40,6 @@ curl -X 'GET' \
 
 ```json
 [
-[
   "sendgrid_api_key",
   "open-ai-service-account-key",
   "ghp_your_github_token",
@@ -57,7 +56,6 @@ curl -X 'GET' \
   "neutrino_user_id",
   "weather-api",
   "slack_standup_token"
-]
 ]
 ```
 

--- a/docs/reference-docs/system-tasks/business-rule.mdx
+++ b/docs/reference-docs/system-tasks/business-rule.mdx
@@ -114,6 +114,9 @@ The Business rule task will return the following parameters.
 | Parameter | Description                                                                                                                                                                        |
 | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | result    | Contains the evaluated parameters based on the matching rule. The specific parameters inside the `result` object depend on the output columns specified in the task configuration. |
+| matchedRows <TableNote title="Available since"><ul><li>v5.5.2 and later</li></ul></TableNote> | A list containing one entry per rule that fired, in fire order. Each entry has the same output columns as `result`. |
+
+Regardless of `executionStrategy`, `matchedRows` lists every rule that fired, one entry per row, in fire order, and is empty if none matched. `result` keeps its last-wins behavior unchanged, so existing workflows are unaffected. With `FIRE_FIRST`, `matchedRows` has at most one entry. With `FIRE_ALL`, it can have several.
 
 ## Examples
 
@@ -306,5 +309,83 @@ For example:
 - At 10:08 AM, task C runs with `cacheTimeoutMinutes` set to 5 . It also uses the cached `fileA`.
 - At 10:10 AM, the initial cache expires.
 - At 10:15 AM, task D runs with `cacheTimeoutMinutes` set to 30. Because the previous cache has expired, it downloads `fileA` again and caches it for 30 minutes. Any task using this file within the next 30 minutes will use the cached version.
+
+</details>
+
+<details markdown="1">
+<summary>Using `matchedRows` to see every fired rule</summary>
+
+To see how `matchedRows` differs from `result`, consider the following rule file:
+
+```
+shippingMethod,containerSize,shippingCharge
+mail,Any,10
+mail,small,15
+Any,small,20
+```
+
+Save this as `shipping-rules.csv` and upload it to a publicly accessible location. Note the file URL.
+
+Use it in a workflow with the following configuration:
+
+```json
+{
+  "name": "business_rule",
+  "taskReferenceName": "business_rule_ref",
+  "inputParameters": {
+    "ruleFileLocation": "https://example-bucket.s3.amazonaws.com/shipping-rules.csv",
+    "executionStrategy": "FIRE_ALL",
+    "inputColumns": {
+      "shippingMethod": "${workflow.input.shippingMethod}",
+      "containerSize": "${workflow.input.containerSize}"
+    },
+    "outputColumns": [
+      "shippingCharge"
+    ]
+  },
+  "type": "BUSINESS_RULE"
+}
+```
+
+**Case 1: FIRE_ALL, input matches all three rows**
+
+With the input:
+
+```json
+{
+  "shippingMethod": "mail",
+  "containerSize": "small"
+}
+```
+
+All three rows match. With `FIRE_ALL`, each firing rule overwrites `result`, so only the last one survives there, but `matchedRows` keeps all three:
+
+```json
+{
+  "result": {
+    "shippingCharge": "20"
+  },
+  "matchedRows": [
+    { "shippingCharge": "10" },
+    { "shippingCharge": "15" },
+    { "shippingCharge": "20" }
+  ]
+}
+```
+
+**Case 2: FIRE_FIRST, same input**
+
+With `executionStrategy` changed to `FIRE_FIRST` and the same input, all three rows still match, but only the first one fires:
+
+```json
+{
+  "result": {
+    "shippingCharge": "10"
+  },
+  "matchedRows": [
+    { "shippingCharge": "10" }
+  ]
+}
+```
 
 </details>

--- a/docs/reference-docs/system-tasks/grpc.mdx
+++ b/docs/reference-docs/system-tasks/grpc.mdx
@@ -6,6 +6,7 @@ description:  "Learn how the gRPC task invokes remote gRPC service endpoints fro
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import TableNote from '@site/src/components/TableNote';
 
 # gRPC
 
@@ -30,6 +31,7 @@ Configure these parameters for the gRPC task.
 | inputParameters.**headers** | A map of additional headers to be sent along with the request. Supported types:<ul><li>Accept-Language</li><li>Authorization</li><li>Cache Control</li><li>Content-MD5</li><li>From</li><li>If-Match</li><li>If-Modified-Since</li><li>If-None-Match</li><li>Max-Forwards</li><li>Pragma</li><li>If-Range</li><li>If-Unmodified-Since</li><li>Proxy-Authorization</li><li>Range</li><li>Warning</li><li>x-api-key</li><li>Accept-Charset</li><li>Accept-Encoding</li><li>Accept-Control-Request-Headers</li><li>Accept-Control-Request-Method</li><li>Content-Transfer-Encoding</li><li>Expect</li><li>Transfer-Encoding</li><li>Trailer</li></ul> | Optional. | 
 | inputParameters.**inputType** | The input schema for the request. [Learn more about using schemas in Conductor](https://orkes.io/content/developer-guides/schema-validation#inputoutput-schema-validation).<ul><li>If you’re using a [registered service](https://orkes.io/content/remote-services), this value is the schema name automatically registered when fetching the service definition.</li><li>If you’re configuring the task manually, enter the name of the input schema you want to associate with the task.</li></ul> | Optional. | 
 | inputParameters.**outputType** | The output schema for the response. [Learn more about using schemas in Conductor](https://orkes.io/content/developer-guides/schema-validation#inputoutput-schema-validation).<ul><li>If you’re using a [registered service](https://orkes.io/content/remote-services), this value is the schema name automatically registered when fetching the service definition.</li><li>If you’re configuring the task manually, enter the name of the output schema you want to associate with the task.</li></ul> | Optional. | 
+| inputParameters.**compressionCodec** <TableNote title="Available since"><ul><li>v5.5.2 and later</li></ul></TableNote> | Compresses request and response messages on the wire. Set to `gzip` to enable compression. Useful for reducing transfer size on large payloads. | Optional. | 
 
 The following are generic configuration parameters that can be applied to the task and are not specific to the gRPC task.
 
@@ -82,7 +84,8 @@ This is the task configuration for a gRPC task.
        },
        "headers": {
          "x-api-key": "${workflow.secrets.api}"
-       }
+       },
+       "compressionCodec": "gzip"
      }
    }
 ```


### PR DESCRIPTION
Doc updates for v5.5.2 changes:

- Document `matchedRows` output for the Business Rule task (FIRE_ALL now surfaces every fired rule, not just the last)
- Document `compressionCodec` input field for the gRPC task
- Document the 500 response for Delete Application
- Document implicit READ (satisfied by UPDATE/DELETE/EXECUTE) for List Accessible Secrets, plus a stray-bracket fix in an existing example

🤖 Generated with [Claude Code](https://claude.com/claude-code)